### PR TITLE
feat(tablet invoice): remove copy to clipboard from tablet

### DIFF
--- a/app/javascript/components/app-invoice.vue
+++ b/app/javascript/components/app-invoice.vue
@@ -63,6 +63,8 @@
 import { mapState, mapActions, mapGetters } from 'vuex';
 import loading from './loading.vue';
 
+const LENOVO_TAB_4_WIDTH = 1000;
+
 export default {
   components: {
     loading,
@@ -83,8 +85,7 @@ export default {
       return this.status ? '¡Pagado!' : 'Esperando pago...';
     },
     showCopy() {
-      const minScreenWidth = 1000;
-      const isTablet = /(android)/i.test(navigator.userAgent) && screen.width > minScreenWidth;
+      const isTablet = /(android)/i.test(navigator.userAgent) && screen.width > LENOVO_TAB_4_WIDTH;
 
       return (this.invoice.payment_request && !isTablet);
     },

--- a/app/javascript/components/app-invoice.vue
+++ b/app/javascript/components/app-invoice.vue
@@ -19,7 +19,7 @@
       <div
         class="invoice__copy"
         @click="copyPaymentRequest"
-        v-if="invoice.payment_request"
+        v-if="showCopy"
       >
         <div class="invoice__copy-value">
           {{ invoice.payment_request }}
@@ -81,6 +81,12 @@ export default {
     }),
     statusVerbose() {
       return this.status ? '¡Pagado!' : 'Esperando pago...';
+    },
+    showCopy() {
+      const minScreenWidth = 1000;
+      const isTablet = /(android)/i.test(navigator.userAgent) && screen.width > minScreenWidth;
+
+      return (this.invoice.payment_request && !isTablet);
     },
   },
   methods: {


### PR DESCRIPTION
Se quita la opción de copiar el `payment_request` del tablet.