### PR TITLE
fix(user-products): update user product as inactive instead of deleti…

### DIFF
--- a/app/controllers/user_products_controller.rb
+++ b/app/controllers/user_products_controller.rb
@@ -4,7 +4,7 @@ class UserProductsController < ApplicationController
 
   def index
     @withdrawable_amount = current_user.withdrawable_amount
-    @user_products = current_user.products_with_sales
+    @user_products = current_user.products_with_sales.actives
   end
 
   def new
@@ -29,7 +29,7 @@ class UserProductsController < ApplicationController
   end
 
   def destroy
-    user_product.destroy!
+    user_product.update!(active: false)
     redirect_to user_products_path
   end
 

--- a/app/controllers/user_products_controller.rb
+++ b/app/controllers/user_products_controller.rb
@@ -4,7 +4,7 @@ class UserProductsController < ApplicationController
 
   def index
     @withdrawable_amount = current_user.withdrawable_amount
-    @user_products = current_user.products_with_sales.actives
+    @user_products = current_user.products_with_sales.active
   end
 
   def new

--- a/app/models/user_product.rb
+++ b/app/models/user_product.rb
@@ -2,10 +2,10 @@ class UserProduct < ApplicationRecord
   validates :price, :stock, presence: true
   validates :price, :stock, numericality: { greater_than_or_equal_to: 0 }
 
-  scope :actives, -> { where(active: true) }
+  scope :active, -> { where(active: true) }
   scope :with_stock, -> { where('stock > 0') }
 
-  scope :for_sale, -> { actives.with_stock }
+  scope :for_sale, -> { active.with_stock }
 
   belongs_to :user
   belongs_to :product

--- a/app/serializers/product_serializer.rb
+++ b/app/serializers/product_serializer.rb
@@ -6,7 +6,7 @@ class ProductSerializer < ActiveModel::Serializer
   has_many :user_products
 
   def user_products
-    @object.user_products.with_stock.actives
+    @object.user_products.for_sale
   end
 
   def image_url

--- a/app/serializers/product_serializer.rb
+++ b/app/serializers/product_serializer.rb
@@ -6,7 +6,7 @@ class ProductSerializer < ActiveModel::Serializer
   has_many :user_products
 
   def user_products
-    @object.user_products.with_stock
+    @object.user_products.with_stock.actives
   end
 
   def image_url

--- a/spec/controllers/user_products_controller_spec.rb
+++ b/spec/controllers/user_products_controller_spec.rb
@@ -255,14 +255,14 @@ RSpec.describe UserProductsController, type: :controller do
       before { mock_authentication }
 
       it 'deletes correct product' do
-        expect(UserProduct.find_by(id: product_to_delete.id)).not_to be(nil)
+        expect(UserProduct.find_by(id: product_to_delete.id).active).to be(true)
         delete :destroy, params: { id: product_to_delete.id }
-        expect(UserProduct.find_by(id: product_to_delete.id)).to be(nil)
+        expect(UserProduct.find_by(id: product_to_delete.id).active).to be(false)
       end
 
-      it 'deletes only one product' do
+      it 'does not delete product from DB' do
         expect { delete :destroy, params: { id: product_to_delete.id } }
-          .to change(UserProduct, :count).by(-1)
+          .to change(UserProduct, :count).by(0)
       end
     end
   end

--- a/spec/models/user_product_spec.rb
+++ b/spec/models/user_product_spec.rb
@@ -29,16 +29,16 @@ RSpec.describe UserProduct, type: :model do
     end
   end
 
-  describe 'actives scope' do
+  describe 'active scope' do
     let!(:user_product_a) { create(:user_product, active: false) }
     let!(:user_product_b) { create(:user_product) }
 
     it 'only returns one active user product' do
-      expect(UserProduct.actives).to have_attributes(length: 1)
+      expect(UserProduct.active).to have_attributes(length: 1)
     end
 
     it 'returns correct user product' do
-      expect(UserProduct.actives.first.id).to eq(user_product_b.id)
+      expect(UserProduct.active.first.id).to eq(user_product_b.id)
     end
   end
 


### PR DESCRIPTION
…ng from DB when user deletes it

No se podían registrar en el sistema contable las ventas correspondientes a `UserProducts` que hubieran sido eliminados por el usuario. Para evitar este problema, se evita que los productos se borren de la BD, cambiando el método `destroy` para que registre el producto como inactivo en vez de eliminarlo.
Se agrega el filtro `actives` para los `user_products` que se muestran en el perfil del usuario, y en el serializer de `products`, para asegurar que no se puedan vender/comprar/editar productos inactivos.