### PR TITLE
fix(products-refresh): don't refresh page while cart is not empty

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script>
-import { mapGetters } from 'vuex';
+import { mapGetters, mapState } from 'vuex';
 
 import appResume from './components/app-resume.vue';
 import appInvoice from './components/app-invoice.vue';
@@ -44,8 +44,20 @@ export default {
       'products': 'productsAsArray',
       'totalAmount': 'totalAmount',
     }),
+    ...mapState(['emptyCart']),
     sortedProductList() {
       return [...this.products].sort((a, b) => a.name.localeCompare(b.name));
+    },
+  },
+  watch: {
+    emptyCart(newValue) {
+      if (newValue) {
+        this.interval = setInterval(() => {
+          this.$store.dispatch('getProducts');
+        }, REFRESH_INTERVAL_TIME);
+      } else {
+        clearInterval(this.interval);
+      }
     },
   },
   mounted() {

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -25,13 +25,11 @@
 </template>
 
 <script>
-import { mapGetters, mapState } from 'vuex';
+import { mapGetters } from 'vuex';
 
 import appResume from './components/app-resume.vue';
 import appInvoice from './components/app-invoice.vue';
 import product from './components/product.vue';
-
-const REFRESH_INTERVAL_TIME = 120000;
 
 export default {
   components: {
@@ -44,30 +42,12 @@ export default {
       'products': 'productsAsArray',
       'totalAmount': 'totalAmount',
     }),
-    ...mapState(['emptyCart']),
     sortedProductList() {
       return [...this.products].sort((a, b) => a.name.localeCompare(b.name));
     },
   },
-  watch: {
-    emptyCart(newValue) {
-      if (newValue) {
-        this.interval = setInterval(() => {
-          this.$store.dispatch('getProducts');
-        }, REFRESH_INTERVAL_TIME);
-      } else {
-        clearInterval(this.interval);
-      }
-    },
-  },
   mounted() {
     this.$store.dispatch('getProducts');
-    this.interval = setInterval(() => {
-      this.$store.dispatch('getProducts');
-    }, REFRESH_INTERVAL_TIME);
-  },
-  destroyed() {
-    clearInterval(this.interval);
   },
 };
 </script>

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -60,7 +60,7 @@ const store = new Vuex.Store({
           return acc;
         }, {});
         context.commit('setProducts', products);
-        context.dispatch('starGetProductsInterval');
+        context.dispatch('startGetProductsInterval');
       });
     },
     decrementProduct: (context, payload) => {
@@ -68,7 +68,7 @@ const store = new Vuex.Store({
       context.commit('setActionProduct', payload.id);
       context.commit('setActionMessage', 'decrement');
       context.commit('setProduct', { ...payload, amount });
-      context.dispatch('starGetProductsInterval');
+      context.dispatch('startGetProductsInterval');
       context.dispatch('buy');
     },
     incrementProduct: (context, payload) => {
@@ -115,7 +115,7 @@ const store = new Vuex.Store({
         context.commit('setProduct', { ...product, amount: 0 });
       });
       context.commit('setLoading', false);
-      context.dispatch('starGetProductsInterval');
+      context.dispatch('startGetProductsInterval');
     },
     cleanInvoice: context => {
       context.commit('setInvoice', {});
@@ -132,8 +132,8 @@ const store = new Vuex.Store({
     setLoading: (context, payload) => {
       context.commit('setLoading', payload);
     },
-    starGetProductsInterval: context => {
-      if (context.getters.totalAmount === 0 && context.state.intervalId === null) {
+    startGetProductsInterval: context => {
+      if (context.getters.totalAmount === 0 && !context.state.intervalId) {
         const interval = setInterval(() => {
           context.dispatch('getProducts');
         }, REFRESH_INTERVAL_TIME);

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -14,6 +14,7 @@ const store = new Vuex.Store({
     loading: false,
     actionMessage: '',
     actionProductId: null,
+    emptyCart: true,
   },
   mutations: {
     setProduct: (state, payload) => {
@@ -44,6 +45,9 @@ const store = new Vuex.Store({
     setLoading: (state, payload) => {
       state.loading = payload;
     },
+    setEmptyCart: (state, payload) => {
+      state.emptyCart = payload;
+    },
   },
   actions: {
     getProducts: context => {
@@ -61,6 +65,7 @@ const store = new Vuex.Store({
       context.commit('setActionProduct', payload.id);
       context.commit('setActionMessage', 'decrement');
       context.commit('setProduct', { ...payload, amount });
+      context.dispatch('setEmptyCart');
       context.dispatch('buy');
     },
     incrementProduct: (context, payload) => {
@@ -68,15 +73,15 @@ const store = new Vuex.Store({
         context.dispatch('updateProduct', payload);
       }
       const userProduct = payload.user_products.sort((a, b) => (a.price > b.price))[0];
+      context.commit('setActionProduct', payload.id);
       if (userProduct.stock > payload.amount) {
-        context.commit('setActionProduct', payload.id);
         context.commit('setActionMessage', 'increment');
         context.commit('setProduct', { ...payload, amount: payload.amount + 1 });
         context.dispatch('buy');
       } else {
-        context.commit('setActionProduct', payload.id);
         context.commit('setActionMessage', 'maxStock');
       }
+      context.dispatch('setEmptyCart');
     },
     updateProduct: (context, payload) => {
       api.product(payload.id).then((response) => {
@@ -107,6 +112,7 @@ const store = new Vuex.Store({
         context.commit('setProduct', { ...product, amount: 0 });
       });
       context.commit('setLoading', false);
+      context.dispatch('setEmptyCart');
     },
     cleanInvoice: context => {
       context.commit('setInvoice', {});
@@ -122,6 +128,13 @@ const store = new Vuex.Store({
     },
     setLoading: (context, payload) => {
       context.commit('setLoading', payload);
+    },
+    setEmptyCart: context => {
+      if (context.getters.totalAmount === 0) {
+        context.commit('setEmptyCart', true);
+      } else {
+        context.commit('setEmptyCart', false);
+      }
     },
   },
   getters: {


### PR DESCRIPTION
Se corrige un bug que reseteaba el carro de compras al refrescarse automáticamente la página cada 2 minutos. 
Para esto, se desactiva la actualización automática con `clearInterval` cuando el carro no está vacío, y se activa con `setInterval` cuando el carro se vacía.