### PR TITLE
Fix/register invoice job

### DIFF
--- a/app/jobs/register_invoice_payment_job.rb
+++ b/app/jobs/register_invoice_payment_job.rb
@@ -1,7 +1,8 @@
 class RegisterInvoicePaymentJob < ApplicationJob
   queue_as :ledger_transaction
 
-  def perform(invoice)
+  def perform(invoice_id)
+    invoice = Invoice.find(invoice_id)
     RegisterInvoicePayment.for(invoice: invoice)
   end
 end

--- a/app/observers/invoice_observer.rb
+++ b/app/observers/invoice_observer.rb
@@ -2,6 +2,6 @@ class InvoiceObserver < PowerTypes::Observer
   after_save :register_invoice_payment
 
   def register_invoice_payment
-    RegisterInvoicePaymentJob.perform_later(object)
+    RegisterInvoicePaymentJob.set(wait: 2.seconds).perform_later(object.id)
   end
 end

--- a/spec/jobs/register_invoice_payment_job_spec.rb
+++ b/spec/jobs/register_invoice_payment_job_spec.rb
@@ -9,21 +9,21 @@ RSpec.describe RegisterInvoicePaymentJob, type: :job do
 
   let(:invoice) { create(:invoice) }
 
-  describe "#perform_later" do
+  describe '#perform_later' do
     it do
       expect do
-        RegisterInvoicePaymentJob.perform_later(invoice)
-      end.to have_enqueued_job.on_queue("ledger_transaction")
+        RegisterInvoicePaymentJob.perform_later(invoice.id)
+      end.to have_enqueued_job.on_queue('ledger_transaction')
     end
   end
 
-  describe "#perform_now" do
+  describe '#perform_now' do
     before do
       allow(RegisterInvoicePayment).to receive(:for).with(invoice: invoice)
     end
 
     it do
-      RegisterInvoicePaymentJob.perform_now(invoice)
+      RegisterInvoicePaymentJob.perform_now(invoice.id)
       expect(RegisterInvoicePayment).to have_received(:for).with(invoice: invoice)
     end
   end

--- a/spec/observers/invoice_observer_spec.rb
+++ b/spec/observers/invoice_observer_spec.rb
@@ -5,23 +5,19 @@ describe InvoiceObserver do
     described_class.trigger(_type, _event, invoice)
   end
 
-  let(:invoice) { build(:invoice) }
+  let(:invoice) { create(:invoice) }
 
-  before do
-    allow(RegisterInvoicePaymentJob).to receive(:perform_later).with(invoice)
-  end
-
-  context "when invoice is save" do
+  context 'when invoice is save' do
     it do
       trigger(:after, :save)
-      expect(RegisterInvoicePaymentJob).to have_received(:perform_later).with(invoice)
+      expect { RegisterInvoicePaymentJob.to have_enqueued_job.with(invoice.id) }
     end
   end
 
-  context "when invoice is not save" do
+  context 'when invoice is not save' do
     it do
       trigger(:before, :save)
-      expect(RegisterInvoicePaymentJob).to_not have_received(:perform_later)
+      expect { RegisterInvoicePaymentJob.to_not have_enqueued_job }
     end
   end
 end


### PR DESCRIPTION
- Se agrega un `wait` de 2 segundos a `RegisterInvoicePaymentJob`.
- Se actualiza `RegisterInvoicePayment` para que reciba un id en vez de un objeto.