### PR TITLE
Retire ln

### DIFF
--- a/app/clients/lightning_network_client.rb
+++ b/app/clients/lightning_network_client.rb
@@ -7,7 +7,7 @@ class LightningNetworkClient
   base_uri "https://#{LND_HOST}:#{LND_PORT}/v1"
 
   def invoices
-    check_success self.class.get("/invoices", headers: headers, verify: false)
+    check_success self.class.get('/invoices', headers: headers, verify: false)
   end
 
   def invoice(r_hash)
@@ -16,11 +16,24 @@ class LightningNetworkClient
 
   def create_invoice(memo, amount)
     check_success self.class.post(
-      "/invoices",
+      '/invoices',
       body: { memo: memo, value: amount }.to_json,
       headers: headers,
       verify: false
     )
+  end
+
+  def transaction(payment_request)
+    check_success self.class.post(
+      '/channels/transactions',
+      body: { payment_request: payment_request },
+      headers: headers,
+      verify: false
+    )
+  end
+
+  def decode_payment_request(payment_request)
+    check_success self.class.get("/payreq/#{payment_request}", headers: headers, verify: false)
   end
 
   private

--- a/app/clients/lightning_network_client.rb
+++ b/app/clients/lightning_network_client.rb
@@ -26,7 +26,7 @@ class LightningNetworkClient
   def transaction(payment_request)
     check_success self.class.post(
       '/channels/transactions',
-      body: { payment_request: payment_request },
+      body: { payment_request: payment_request }.to_json,
       headers: headers,
       verify: false
     )

--- a/app/commands/pay_invoice_to_user.rb
+++ b/app/commands/pay_invoice_to_user.rb
@@ -1,0 +1,8 @@
+class PayInvoiceToUser < PowerTypes::Command.new(:invoice_hash, :user)
+  def perform
+    LightningNetworkWithdrawal.create(
+      invoice_hash: invoice_hash,
+      user_id: user.id
+    )
+  end
+end

--- a/app/commands/pay_invoice_to_user.rb
+++ b/app/commands/pay_invoice_to_user.rb
@@ -1,8 +1,8 @@
 class PayInvoiceToUser < PowerTypes::Command.new(:invoice_hash, :user)
   def perform
     LightningNetworkWithdrawal.create(
-      invoice_hash: invoice_hash,
-      user_id: user.id
+      invoice_hash: @invoice_hash,
+      user_id: @user.id
     )
   end
 end

--- a/app/commands/process_lightning_network_withdrawal.rb
+++ b/app/commands/process_lightning_network_withdrawal.rb
@@ -1,0 +1,50 @@
+class ProcessLightningNetworkWithdrawal < PowerTypes::Command.new(:lightning_withdrawal)
+  def perform
+    decode_invoice
+
+    if enough_funds?
+      process_payment
+    else
+      reject_payment
+    end
+  end
+
+  private
+
+  def decode_invoice
+    decoded_invoice = lightning_network_client
+                      .decode_payment_request(@lightning_withdrawal.invoice_hash)
+    @lightning_withdrawal.amount = decoded_invoice['num_satoshis'].to_i
+    @lightning_withdrawal.memo = decoded_invoice['description']
+    @lightning_withdrawal.save!
+  end
+
+  def enough_funds?
+    withdrawal_user_withdrawable_amount >= withdrawal_amount
+  end
+
+  def process_payment
+    ActiveRecord::Base.transaction do
+      @lightning_withdrawal.confirm!
+      RegisterLightningNetworkWithdrawalPayment.for(lightning_withdrawal: @lightning_withdrawal)
+      lightning_network_client.transaction(@lightning_withdrawal.invoice_hash)
+    end
+  end
+
+  def reject_payment
+    @lightning_withdrawal.reject!
+  end
+
+  def withdrawal_user_withdrawable_amount
+    @withdrawal_user_withdrawable_amount ||= User.find(@lightning_withdrawal.user_id)
+                                                 .withdrawable_amount
+  end
+
+  def withdrawal_amount
+    @withdrawal_amount ||= @lightning_withdrawal.amount
+  end
+
+  def lightning_network_client
+    @lightning_network_client ||= LightningNetworkClient.new
+  end
+end

--- a/app/commands/register_lightning_network_withdrawal_payment.rb
+++ b/app/commands/register_lightning_network_withdrawal_payment.rb
@@ -1,0 +1,35 @@
+class RegisterLightningNetworkWithdrawalPayment < PowerTypes::Command.new(:lightning_withdrawal)
+  PLATANUS_WALLET_ID = ENV.fetch('PLATANUS_WALLET_ID')
+
+  def perform
+    return unless @lightning_withdrawal.confirmed?
+
+    Ledger::Transfer.for(
+      from: lightning_account,
+      to: debt_to_seller_account,
+      countable: @lightning_withdrawal,
+      amount: @lightning_withdrawal.amount,
+      date: @lightning_withdrawal.created_at
+    )
+  end
+
+  private
+
+  def debt_to_seller_account
+    LedgerAccount.find_or_create_by!(
+      accountable: lightning_withdrawal_user,
+      category: 'DebtToSellers'
+    )
+  end
+
+  def lightning_account
+    LedgerAccount.find_or_create_by!(
+      accountable: Wallet.find(PLATANUS_WALLET_ID), # platanus node
+      category: 'Wallet'
+    )
+  end
+
+  def lightning_withdrawal_user
+    @lightning_withdrawal_user ||= User.find(@lightning_withdrawal.user_id)
+  end
+end

--- a/app/jobs/process_lightning_network_withdrawal_job.rb
+++ b/app/jobs/process_lightning_network_withdrawal_job.rb
@@ -1,0 +1,7 @@
+class ProcessLightningNetworkWithdrawalJob < ApplicationJob
+  queue_as :ledger_transaction
+
+  def perform(lightning_withdrawal)
+    ProcessLightningNetworkWithdrawal.for(lightning_withdrawal: lightning_withdrawal)
+  end
+end

--- a/app/jobs/register_lightning_network_withdrawal_payment_job.rb
+++ b/app/jobs/register_lightning_network_withdrawal_payment_job.rb
@@ -1,0 +1,7 @@
+class RegisterLightningNetworkWithdrawalPaymentJob < ApplicationJob
+  queue_as :ledger_transaction
+
+  def perform(lightning_withdrawal)
+    RegisterLightningNetworkWithdrawalPayment.for(lightning_withdrawal: lightning_withdrawal)
+  end
+end

--- a/app/jobs/register_withdrawal_payment_job.rb
+++ b/app/jobs/register_withdrawal_payment_job.rb
@@ -1,0 +1,7 @@
+class RegisterWithdrawalPaymentJob < ApplicationJob
+  queue_as :ledger_transaction
+
+  def perform(withdrawal)
+    RegisterWithdrawalPayment.for(withdrawal: withdrawal)
+  end
+end

--- a/app/models/lightning_network_withdrawal.rb
+++ b/app/models/lightning_network_withdrawal.rb
@@ -1,0 +1,31 @@
+class LightningNetworkWithdrawal < ApplicationRecord
+  include AASM
+  aasm do
+    state :pending, initial: true
+    state :confirmed, :rejected
+
+    event :confirm do
+      transitions from: :pending, to: :confirmed
+    end
+
+    event :reject do
+      transitions from: :pending, to: :rejected
+    end
+  end
+end
+
+# == Schema Information
+#
+# Table name: lightning_network_withdrawals
+#
+#  id           :bigint(8)        not null, primary key
+#  invoice_hash :string
+#  state        :string
+#  user_id      :bigint(8)        not null
+#  created_at   :datetime         not null
+#  updated_at   :datetime         not null
+#
+# Indexes
+#
+#  index_lightning_network_withdrawals_on_user_id  (user_id)
+#

--- a/app/models/lightning_network_withdrawal.rb
+++ b/app/models/lightning_network_withdrawal.rb
@@ -1,6 +1,7 @@
 class LightningNetworkWithdrawal < ApplicationRecord
+  include PowerTypes::Observable
   include AASM
-  aasm do
+  aasm column: 'state' do
     state :pending, initial: true
     state :confirmed, :rejected
 
@@ -19,11 +20,13 @@ end
 # Table name: lightning_network_withdrawals
 #
 #  id           :bigint(8)        not null, primary key
-#  invoice_hash :string
+#  invoice_hash :string           not null
 #  state        :string
 #  user_id      :bigint(8)        not null
 #  created_at   :datetime         not null
 #  updated_at   :datetime         not null
+#  amount       :integer
+#  memo         :string
 #
 # Indexes
 #

--- a/app/observers/lightning_network_withdrawal_observer.rb
+++ b/app/observers/lightning_network_withdrawal_observer.rb
@@ -1,0 +1,7 @@
+class LightningNetworkWithdrawalObserver < PowerTypes::Observer
+  after_create :process_lightning_network_withdrawal
+
+  def process_lightning_network_withdrawal
+    ProcessLightningNetworkWithdrawalJob.set(wait: 5.seconds).perform_later(object)
+  end
+end

--- a/app/observers/withdrawal_observer.rb
+++ b/app/observers/withdrawal_observer.rb
@@ -2,6 +2,6 @@ class WithdrawalObserver < PowerTypes::Observer
   after_save :register_withdrawal_payment
 
   def register_withdrawal_payment
-    RegisterWithdrawalPayment.for(withdrawal: object)
+    RegisterWithdrawalPaymentJob.set(wait: 5.seconds).perform_later(object)
   end
 end

--- a/db/migrate/20190531180902_create_lightning_network_withdrawals.rb
+++ b/db/migrate/20190531180902_create_lightning_network_withdrawals.rb
@@ -1,0 +1,11 @@
+class CreateLightningNetworkWithdrawals < ActiveRecord::Migration[5.2]
+  def change
+    create_table :lightning_network_withdrawals do |t|
+      t.string :invoice_hash
+      t.string :state
+      t.references :user, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190531180902_create_lightning_network_withdrawals.rb
+++ b/db/migrate/20190531180902_create_lightning_network_withdrawals.rb
@@ -1,7 +1,7 @@
 class CreateLightningNetworkWithdrawals < ActiveRecord::Migration[5.2]
   def change
     create_table :lightning_network_withdrawals do |t|
-      t.string :invoice_hash
+      t.string :invoice_hash, null: false
       t.string :state
       t.references :user, null: false
 

--- a/db/migrate/20190620161201_add_amount_and_memo_to_lightning_network_withdrawals.rb
+++ b/db/migrate/20190620161201_add_amount_and_memo_to_lightning_network_withdrawals.rb
@@ -1,0 +1,6 @@
+class AddAmountAndMemoToLightningNetworkWithdrawals < ActiveRecord::Migration[5.2]
+  def change
+    add_column :lightning_network_withdrawals, :amount, :int
+    add_column :lightning_network_withdrawals, :memo, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_31_180902) do
+ActiveRecord::Schema.define(version: 2019_06_20_161201) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,11 +107,13 @@ ActiveRecord::Schema.define(version: 2019_05_31_180902) do
   end
 
   create_table "lightning_network_withdrawals", force: :cascade do |t|
-    t.string "invoice_hash"
+    t.string "invoice_hash", null: false
     t.string "state"
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "amount"
+    t.string "memo"
     t.index ["user_id"], name: "index_lightning_network_withdrawals_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_28_175648) do
+ActiveRecord::Schema.define(version: 2019_05_31_180902) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -104,6 +104,15 @@ ActiveRecord::Schema.define(version: 2019_05_28_175648) do
     t.datetime "updated_at", null: false
     t.index ["accountable_type", "accountable_id"], name: "index_ledger_lines_on_accountable_type_and_accountable_id"
     t.index ["ledger_account_id"], name: "index_ledger_lines_on_ledger_account_id"
+  end
+
+  create_table "lightning_network_withdrawals", force: :cascade do |t|
+    t.string "invoice_hash"
+    t.string "state"
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_lightning_network_withdrawals_on_user_id"
   end
 
   create_table "products", force: :cascade do |t|

--- a/spec/clients/lightning_network_client_spec.rb
+++ b/spec/clients/lightning_network_client_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe LightningNetworkClient do
   describe '#create_invoice' do
     before do
       expect(LightningNetworkClient).to receive(:post)
-        .with("/invoices", anything)
+        .with('/invoices', anything)
         .and_return(response)
     end
 
@@ -76,6 +76,55 @@ RSpec.describe LightningNetworkClient do
 
       it 'raises exception' do
         expect { client.create_invoice('memo', 0.1234) }.to raise_error
+      end
+    end
+  end
+
+  describe '#transaction' do
+    before do
+      expect(LightningNetworkClient).to receive(:post)
+        .with('/channels/transactions', anything)
+        .and_return(response)
+    end
+
+    context 'when node returns valid info' do
+      let(:response) { success }
+
+      it 'returns node response' do
+        expect(client.transaction('payment_request')).to eq(response)
+      end
+    end
+
+    context 'when node returns error' do
+      let(:response) { failure }
+
+      it 'raises exception' do
+        expect { client.transaction('payment_request') }.to raise_error
+      end
+    end
+  end
+
+  describe '#decode_payment_request' do
+    let(:payment_request) { 'expected_invoice_hash' }
+    before do
+      expect(LightningNetworkClient).to receive(:get)
+        .with("/payreq/#{payment_request}", anything)
+        .and_return(response)
+    end
+
+    context 'when node returns valid info' do
+      let(:response) { success }
+
+      it 'returns node response' do
+        expect(client.decode_payment_request(payment_request)).to eq(response)
+      end
+    end
+
+    context 'when node returns error' do
+      let(:response) { failure }
+
+      it 'raises exception' do
+        expect { client.decode_payment_request(payment_request) }.to raise_error
       end
     end
   end

--- a/spec/commands/pay_invoice_to_user_spec.rb
+++ b/spec/commands/pay_invoice_to_user_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe PayInvoiceToUser do
+  def perform(*_args)
+    described_class.for(*_args)
+  end
+
+  let(:user) { create(:user) }
+  let(:invoice_hash) { 'ittCgcRP1G7QGdzTWJ1cn6cZ89R7TfAh' }
+
+  it do
+    expect { perform(user: user, invoice_hash: invoice_hash) }
+      .to change { LightningNetworkWithdrawal.all.count }.by(1)
+  end
+end

--- a/spec/commands/process_lightning_network_withdrawal_spec.rb
+++ b/spec/commands/process_lightning_network_withdrawal_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+describe ProcessLightningNetworkWithdrawal do
+  def perform(*_args)
+    described_class.for(*_args)
+  end
+
+  let(:user) { create(:user) }
+  let(:ledger_account) { create(:ledger_account, accountable: user) }
+  let(:lightning_withdrawal) { create(:lightning_network_withdrawal, user_id: user.id) }
+  let(:decode_response_body) do
+    {
+      'num_satoshis' => '10000',
+      'description' => 'withdrawal memo'
+    }
+  end
+
+  before do
+    allow_any_instance_of(LightningNetworkClient).to receive(:decode_payment_request)
+      .with(lightning_withdrawal.invoice_hash)
+      .and_return(decode_response_body)
+    allow_any_instance_of(LightningNetworkClient).to receive(:transaction)
+      .with(lightning_withdrawal.invoice_hash)
+  end
+
+  context 'without enough funds' do
+    before { create(:ledger_line, ledger_account: ledger_account, balance: -5000) }
+    it 'lightning withdrawal is rejected' do
+      perform(lightning_withdrawal: lightning_withdrawal)
+      expect(lightning_withdrawal.state).to eq('rejected')
+    end
+  end
+
+  context 'with enough funds' do
+    before do
+      create(:ledger_line, ledger_account: ledger_account, balance: -10000)
+      expect(RegisterLightningNetworkWithdrawalPayment).to receive(:for)
+        .with(lightning_withdrawal: lightning_withdrawal)
+        .and_return('success')
+    end
+    it 'memo and amount are correctly saved' do
+      perform(lightning_withdrawal: lightning_withdrawal)
+      expect { lightning_withdrawal.amount.to eq(10000) }
+      expect { lightning_withdrawal.memo.to eq('withdrawal memo') }
+    end
+
+    it 'lightning withdrawal is confirmed' do
+      perform(lightning_withdrawal: lightning_withdrawal)
+      expect(lightning_withdrawal.state).to eq('confirmed')
+    end
+
+    it 'lightning withdrawal is registered in ledger' do
+      perform(lightning_withdrawal: lightning_withdrawal)
+    end
+  end
+end

--- a/spec/commands/register_lightning_network_withdrawal_payment_spec.rb
+++ b/spec/commands/register_lightning_network_withdrawal_payment_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+describe RegisterLightningNetworkWithdrawalPayment do
+  def perform(*_args)
+    described_class.for(*_args)
+  end
+
+  before do
+    PowerTypes::Observable.observable_disabled = true
+  end
+
+  after do
+    if PowerTypes::Observable.observable_disabled?
+      PowerTypes::Observable.observable_disabled = false
+    end
+  end
+
+  context 'when a withdrawal is confirmed' do
+    let!(:platanus) { create(:wallet, id: 1) }
+    let(:user_with_invoice) { create(:user_with_invoice) }
+    let(:lightning_account) do
+      create(:ledger_account, accountable: platanus, category: 'Wallet')
+    end
+    let(:user_account) do
+      create(:ledger_account, accountable: user_with_invoice, category: 'DebtToSellers')
+    end
+    let(:lightning_withdrawal) do
+      build(
+        :lightning_network_withdrawal,
+        user_id: user_with_invoice.id,
+        state: 'confirmed'
+      )
+    end
+
+    let(:ledger_transfer_params) do
+      {
+        from: lightning_account,
+        to: user_account,
+        countable: lightning_withdrawal,
+        amount: lightning_withdrawal.amount,
+        date: lightning_withdrawal.created_at
+      }
+    end
+
+    before do
+      expect(Ledger::Transfer).to receive(:for)
+        .with(ledger_transfer_params)
+    end
+
+    it do
+      perform(lightning_withdrawal: lightning_withdrawal)
+    end
+  end
+
+  context 'when a withdrawal is rejected' do
+    let!(:lightning_withdrawal) { build(:lightning_network_withdrawal, state: 'rejected') }
+
+    it do
+      expect(perform(lightning_withdrawal: lightning_withdrawal)).to eq(nil)
+    end
+  end
+end

--- a/spec/factories/lightning_network_withdrawals.rb
+++ b/spec/factories/lightning_network_withdrawals.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :lightning_network_withdrawal do
+    invoice_hash { 'W8LmuwDP0Nk614ktkoeT9JsjiYFEQeap' }
+    state { 'pending' }
+    association :user, factory: :user
+  end
+end

--- a/spec/factories/lightning_network_withdrawals.rb
+++ b/spec/factories/lightning_network_withdrawals.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :lightning_network_withdrawal do
     invoice_hash { 'W8LmuwDP0Nk614ktkoeT9JsjiYFEQeap' }
-    state { 'pending' }
-    association :user, factory: :user
+    user_id { create(:user).id }
   end
 end

--- a/spec/jobs/process_lightning_network_withdrawal_job_spec.rb
+++ b/spec/jobs/process_lightning_network_withdrawal_job_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe ProcessLightningNetworkWithdrawalJob, type: :job do
+  ActiveJob::Base.queue_adapter = :test
+
+  before do
+    PowerTypes::Observable.observable_disabled = true
+  end
+
+  let(:lightning_network_withdrawal) { create(:lightning_network_withdrawal) }
+
+  describe '#perform_later' do
+    it do
+      expect do
+        ProcessLightningNetworkWithdrawalJob.perform_later(lightning_network_withdrawal)
+      end.to have_enqueued_job.on_queue('ledger_transaction')
+    end
+  end
+
+  describe '#perform_now' do
+    before do
+      allow(ProcessLightningNetworkWithdrawal).to receive(:for)
+        .with(lightning_withdrawal: lightning_network_withdrawal)
+    end
+
+    it do
+      ProcessLightningNetworkWithdrawalJob.perform_now(lightning_network_withdrawal)
+      expect(ProcessLightningNetworkWithdrawal).to have_received(:for)
+        .with(lightning_withdrawal: lightning_network_withdrawal)
+    end
+  end
+end

--- a/spec/jobs/register_lightning_network_withdrawal_payment_job_spec.rb
+++ b/spec/jobs/register_lightning_network_withdrawal_payment_job_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe RegisterLightningNetworkWithdrawalPaymentJob, type: :job do
+  ActiveJob::Base.queue_adapter = :test
+
+  before do
+    PowerTypes::Observable.observable_disabled = true
+  end
+
+  let(:lightning_network_withdrawal) { create(:lightning_network_withdrawal) }
+
+  describe '#perform_later' do
+    it do
+      expect do
+        RegisterLightningNetworkWithdrawalPaymentJob.perform_later(lightning_network_withdrawal)
+      end.to have_enqueued_job.on_queue('ledger_transaction')
+    end
+  end
+
+  describe '#perform_now' do
+    before do
+      allow(RegisterLightningNetworkWithdrawalPayment).to receive(:for)
+        .with(lightning_withdrawal: lightning_network_withdrawal)
+    end
+
+    it do
+      RegisterLightningNetworkWithdrawalPaymentJob.perform_now(lightning_network_withdrawal)
+      expect(RegisterLightningNetworkWithdrawalPayment).to have_received(:for)
+        .with(lightning_withdrawal: lightning_network_withdrawal)
+    end
+  end
+end

--- a/spec/models/lightning_network_withdrawal_spec.rb
+++ b/spec/models/lightning_network_withdrawal_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+require 'aasm/rspec'
+
+RSpec.describe LightningNetworkWithdrawal, type: :model do
+  it 'has a valid factory' do
+    lnw = build(:lightning_network_withdrawal)
+    expect(lnw).to be_valid
+  end
+
+  it 'changes state from pending to confirmed' do
+    expect(subject).to transition_from(:pending).to(:confirmed).on_event(:confirm)
+  end
+
+  it 'changes state from pending to rejected' do
+    expect(subject).to transition_from(:pending).to(:rejected).on_event(:reject)
+  end
+end

--- a/spec/observers/invoice_observer_spec.rb
+++ b/spec/observers/invoice_observer_spec.rb
@@ -7,21 +7,17 @@ describe InvoiceObserver do
 
   let(:invoice) { create(:invoice) }
 
-  before do
-    allow(RegisterInvoicePaymentJob).to receive(:perform_later).with(invoice)
-  end
-
   context 'when invoice is save' do
     it do
       trigger(:after, :save)
-      expect { RegisterInvoicePaymentJob.to have_enqueued_job.with(invoice.id) }
+      expect { RegisterInvoicePaymentJob.to receive(:perform_later).with(invoice) }
     end
   end
 
   context 'when invoice is not save' do
     it do
       trigger(:before, :save)
-      expect(RegisterInvoicePaymentJob).to_not have_received(:perform_later)
+      expect { RegisterInvoicePaymentJob.to_not receive(:perform_later) }
     end
   end
 end

--- a/spec/observers/lightning_network_withdrawal_observer_spec.rb
+++ b/spec/observers/lightning_network_withdrawal_observer_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe LightningNetworkWithdrawalObserver do
+  def trigger(_type, _event)
+    described_class.trigger(_type, _event, lightning_network_withdrawal)
+  end
+
+  let(:lightning_network_withdrawal) { create(:lightning_network_withdrawal) }
+
+  context 'when lightning network is created' do
+    it do
+      trigger(:after, :create)
+      expect do
+        ProcessLightningNetworkWithdrawalJob.to receive(:perform_later)
+          .with(lightning_network_withdrawal)
+      end
+    end
+  end
+
+  context 'when lightning network is not created' do
+    it do
+      trigger(:before, :create)
+      expect { ProcessLightningNetworkWithdrawalJob.to_not receive(:perform_later) }
+    end
+  end
+
+  context 'when lightning withdrawal is saved' do
+    it do
+      trigger(:after, :save)
+      expect do
+        RegisterLightningNetworkWithdrawalPaymentJob.to receive(:perform_later)
+          .with(lightning_network_withdrawal)
+      end
+    end
+  end
+
+  context 'when lightning network is not saved' do
+    it do
+      trigger(:before, :save)
+      expect { RegisterLightningNetworkWithdrawalPaymentJob.to_not receive(:perform_later) }
+    end
+  end
+end

--- a/spec/observers/withdrawal_observer_spec.rb
+++ b/spec/observers/withdrawal_observer_spec.rb
@@ -5,24 +5,22 @@ describe WithdrawalObserver do
     described_class.trigger(_type, _event, withdrawal)
   end
 
-  let(:user_with_invoice) { create(:user_with_invoice) }
-  let(:withdrawal) { build(:withdrawal, user: user_with_invoice, aasm_state: 'confirmed') }
-
-  before do
-    allow(RegisterWithdrawalPayment).to receive(:for).with(withdrawal: withdrawal)
+  let(:user_with_account) { create(:user, :with_account) }
+  let(:withdrawal) do
+    build(:withdrawal, id: 123, user: user_with_account, aasm_state: 'confirmed')
   end
 
-  context "when withdrawal is save" do
+  context 'when withdrawal is saved' do
     it do
       trigger(:after, :save)
-      expect(RegisterWithdrawalPayment).to have_received(:for).with(withdrawal: withdrawal)
+      expect { RegisterWithdrawalPaymentJob.to receive(:perform_later).with(withdrawal) }
     end
   end
 
-  context "when invoice is not save" do
+  context 'when withdrawal is not saved' do
     it do
       trigger(:before, :save)
-      expect(RegisterWithdrawalPayment).to_not have_received(:for)
+      expect { RegisterWithdrawalPaymentJob.to_not receive(:perform_later) }
     end
   end
 end


### PR DESCRIPTION
En este PR se agrega la funcionalidad de hacer retiros por consola.
- Se arreglan detalles del procesamiento de pagos de `invoices` y `withdrawals`
- Se agrega el modelo `LightningNetworkWithdrawal`.
- Se agrega un comando para crear un `LightningNetworkWithdrawal`
- Se agregan métodos para solicitar al cliente de `LightningNetwork` que haga transacciones, y que decodee un `payment_request`
- Se agrega el comando `ProcessLightningNetworkWithdrawal`, que realiza la transacción en caso de ser válida.
- Se agrega el comando `RegisterLightningNetworkWithdrawal`, que registra la transacción en el sistema contable de la aplicación.
- Se agrega un observer para `LightningNetworkWithdrawal`, para ejecutar los comandos anteriores cuando corresponda.