### PR TITLE
fix(products-list): re-render products list automatically

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -10,7 +10,7 @@
     <div class="app">
       <div
         class="product-list"
-        key="products"
+        :key="products"
       >
         <product
           v-for="product in sortedProductList"


### PR DESCRIPTION
Se fuerza un re-render del componente `app`, para asegurar que se saquen de la lista de productos comprables los productos que no tienen stock.
Antes, la aplicación no permitía agregar estos productos al carro, pero los seguía mostrando en la lista.