### PR TITLE
fix(products-display): add and remove products from display automatic…

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -45,8 +45,7 @@ export default {
   },
   computed: {
     ...mapGetters({
-      'products': 'productsAsArray',
-      'totalAmount': 'totalAmount',
+      'products': 'onSaleProducts',
     }),
     ...mapState([
       'status',

--- a/app/javascript/components/product.vue
+++ b/app/javascript/components/product.vue
@@ -25,7 +25,7 @@ export default {
     return {};
   },
   mounted() {
-    this.$store.subscribe((mutation) => {
+    this.unsubscribe = this.$store.subscribe((mutation) => {
       if (mutation.type === 'setActionMessage' && this.actionProductId === this.product.id) {
         this.message(this.actionMessage, this.product);
       }
@@ -53,6 +53,9 @@ export default {
       'actionMessage',
       'actionProductId',
     ]),
+  },
+  beforeDestroy() {
+    this.unsubscribe();
   },
 };
 </script>

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -82,13 +82,13 @@ const store = new Vuex.Store({
       const userProduct = payload.user_products.sort((a, b) => (a.price > b.price))[0];
       context.commit('setActionProduct', payload.id);
       if (userProduct.stock > payload.amount) {
-        context.commit('setActionMessage', 'increment');
         context.commit('setProduct', { ...payload, amount: payload.amount + 1 });
+        context.commit('setActionMessage', 'increment');
+        context.dispatch('stopGetProductsInterval');
         context.dispatch('buy');
       } else {
         context.commit('setActionMessage', 'maxStock');
       }
-      context.dispatch('stopGetProductsInterval');
     },
     updateProduct: (context, payload) => {
       api.product(payload.id).then((response) => {
@@ -97,11 +97,11 @@ const store = new Vuex.Store({
     },
     buy: context => {
       if (context.getters.totalAmount) {
-        const products = context.getters.buyProducts;
+        const cartProducts = context.getters.cartProducts;
 
         context.commit('setLoading', true);
 
-        api.buy(products).then((response) => {
+        api.buy(cartProducts).then((response) => {
           context.commit('setInvoice', response.invoice);
           context.commit('setLoading', false);
         });
@@ -166,7 +166,7 @@ const store = new Vuex.Store({
       getters.onSaleProducts.reduce((acc, product) => acc + product.user_products
         .sort((a, b) => (a.price - b.price))[0].price * product.amount, 0)
     ),
-    buyProducts: (state, getters) => {
+    cartProducts: (state, getters) => {
       const products = getters.productsAsArray.reduce((acc, product) => {
         if (product.amount > 0) {
           acc[product.id] = {


### PR DESCRIPTION
…ally

Cuando un producto se quedaba sin stock, no estaba desapareciendo del display. En este PR se corrige ese bug:
- Se cambia la lista de productos que recibe el display, para que reciba solo los productos con stock, en vez de todos los productos.
- Se agrega un `unsubscribe` al componente `product`. Con esto se evita que, cada vez que se agrega un producto al carro, se muestren alertas de que un producto que fue eliminado del display se agregó al carro.
- Aproveché de cambiar el nombre del `getter` `buyProducts` a `cartProducts`, para que quede más claro que hace.