### PR TITLE
Fix/handle invalid hash invoices

### DIFF
--- a/app/commands/pay_invoice_to_user.rb
+++ b/app/commands/pay_invoice_to_user.rb
@@ -2,7 +2,20 @@ class PayInvoiceToUser < PowerTypes::Command.new(:invoice_hash, :user)
   def perform
     LightningNetworkWithdrawal.create(
       invoice_hash: @invoice_hash,
-      user_id: @user.id
+      user_id: @user.id,
+      amount: decoded_invoice['num_satoshis'].to_i,
+      memo: decoded_invoice['description']
     )
+  end
+
+  private
+
+  def decoded_invoice
+    @decoded_invoice ||= lightning_network_client
+                         .decode_payment_request(@invoice_hash)
+  end
+
+  def lightning_network_client
+    @lightning_network_client ||= LightningNetworkClient.new
   end
 end

--- a/app/commands/process_lightning_network_withdrawal.rb
+++ b/app/commands/process_lightning_network_withdrawal.rb
@@ -1,7 +1,5 @@
 class ProcessLightningNetworkWithdrawal < PowerTypes::Command.new(:lightning_withdrawal)
   def perform
-    decode_invoice
-
     if enough_funds?
       process_payment
     else
@@ -10,14 +8,6 @@ class ProcessLightningNetworkWithdrawal < PowerTypes::Command.new(:lightning_wit
   end
 
   private
-
-  def decode_invoice
-    decoded_invoice = lightning_network_client
-                      .decode_payment_request(@lightning_withdrawal.invoice_hash)
-    @lightning_withdrawal.amount = decoded_invoice['num_satoshis'].to_i
-    @lightning_withdrawal.memo = decoded_invoice['description']
-    @lightning_withdrawal.save!
-  end
 
   def enough_funds?
     withdrawal_user_withdrawable_amount >= withdrawal_amount

--- a/app/controllers/lightning_network_withdrawals_controller.rb
+++ b/app/controllers/lightning_network_withdrawals_controller.rb
@@ -10,8 +10,9 @@ class LightningNetworkWithdrawalsController < ApplicationController
       invoice_hash: lightning_network_withdrawal_params[:invoice_hash],
       user: current_user
     )
-
-    render 'feedback'
+    render 'successful'
+  rescue LightningNetworkClientError::ClientError
+    render 'unsuccessful'
   end
 
   private

--- a/app/views/lightning_network_withdrawals/feedback.js.erb
+++ b/app/views/lightning_network_withdrawals/feedback.js.erb
@@ -1,4 +1,0 @@
-/* eslint-env jquery */
-
-$('#withdrawal-modal-holder').modal('hide');
-$('#products-index-table-container').prepend('<div class="alert alert-success"> Se ha enviado una solicitud de retiro. </div>');

--- a/app/views/lightning_network_withdrawals/successful.js.erb
+++ b/app/views/lightning_network_withdrawals/successful.js.erb
@@ -1,0 +1,4 @@
+/* eslint-env jquery */
+
+$('#withdrawal-modal-holder').modal('hide');
+$('#products-index-table-container').prepend('<div class="alert alert-success"> Solicitud de retiro enviada </div>');

--- a/app/views/lightning_network_withdrawals/unsuccessful.js.erb
+++ b/app/views/lightning_network_withdrawals/unsuccessful.js.erb
@@ -1,0 +1,4 @@
+/* eslint-env jquery */
+
+$('#withdrawal-modal-holder').modal('hide');
+$('#products-index-table-container').prepend('<div class="alert alert-danger"> Hash inválido </div>');

--- a/spec/commands/pay_invoice_to_user_spec.rb
+++ b/spec/commands/pay_invoice_to_user_spec.rb
@@ -7,6 +7,18 @@ describe PayInvoiceToUser do
 
   let(:user) { create(:user) }
   let(:invoice_hash) { 'ittCgcRP1G7QGdzTWJ1cn6cZ89R7TfAh' }
+  let(:decoded_response) do
+    {
+      'num_satoshis' => '10000',
+      'description' => 'withdrawal memo'
+    }
+  end
+
+  before do
+    allow_any_instance_of(LightningNetworkClient).to receive(:decode_payment_request)
+      .with(invoice_hash)
+      .and_return(decoded_response)
+  end
 
   it do
     expect { perform(user: user, invoice_hash: invoice_hash) }

--- a/spec/commands/process_lightning_network_withdrawal_spec.rb
+++ b/spec/commands/process_lightning_network_withdrawal_spec.rb
@@ -8,17 +8,8 @@ describe ProcessLightningNetworkWithdrawal do
   let(:user) { create(:user) }
   let(:ledger_account) { create(:ledger_account, accountable: user) }
   let(:lightning_withdrawal) { create(:lightning_network_withdrawal, user_id: user.id) }
-  let(:decode_response_body) do
-    {
-      'num_satoshis' => '10000',
-      'description' => 'withdrawal memo'
-    }
-  end
 
   before do
-    allow_any_instance_of(LightningNetworkClient).to receive(:decode_payment_request)
-      .with(lightning_withdrawal.invoice_hash)
-      .and_return(decode_response_body)
     allow_any_instance_of(LightningNetworkClient).to receive(:transaction)
       .with(lightning_withdrawal.invoice_hash)
   end

--- a/spec/controllers/lightning_network_withdrawals_controller_spec.rb
+++ b/spec/controllers/lightning_network_withdrawals_controller_spec.rb
@@ -49,15 +49,32 @@ RSpec.describe LightningNetworkWithdrawalsController, type: :controller do
     let(:invoice_hash) { 'invoice hash' }
     let(:action) { :create }
 
-    before do
-      mock_authentication
-      expect(PayInvoiceToUser).to receive(:for)
-        .with(invoice_hash: invoice_hash, user: user)
-        .and_return(true)
+    context 'when no error is raised' do
+      before do
+        mock_authentication
+        expect(PayInvoiceToUser).to receive(:for)
+          .with(invoice_hash: invoice_hash, user: user)
+          .and_return(true)
+      end
+
+      it 'renders successful template' do
+        mock_post_request(invoice_hash, action)
+        expect(subject).to render_template('successful')
+      end
     end
 
-    it 'calls PayInvoiceToUser command' do
-      mock_post_request(invoice_hash, action)
+    context 'when lightning network client error is raised' do
+      before do
+        mock_authentication
+        expect(PayInvoiceToUser).to receive(:for)
+          .with(invoice_hash: invoice_hash, user: user)
+          .and_raise(LightningNetworkClientError::ClientError)
+      end
+
+      it 'renders unsuccessful template' do
+        mock_post_request(invoice_hash, action)
+        expect(subject).to render_template('unsuccessful')
+      end
     end
   end
 end

--- a/spec/factories/lightning_network_withdrawals.rb
+++ b/spec/factories/lightning_network_withdrawals.rb
@@ -2,5 +2,7 @@ FactoryBot.define do
   factory :lightning_network_withdrawal do
     invoice_hash { 'W8LmuwDP0Nk614ktkoeT9JsjiYFEQeap' }
     user_id { create(:user).id }
+    amount { 10000 }
+    memo { 'memo' }
   end
 end


### PR DESCRIPTION
Hasta ahora se estaba asumiendo que el `invoice_hash` ingresado por el usuario para hacer un retiro era válido. En este PR se revisa que el hash sea válido cuando el usuario lo ingresa.
- Se realiza el decodeo del hash antes de crear el `LightningNetworkWithdrawal` asociado, en vez de realizarlo en el procesamiento de este.
- Si el decodeo es exitoso, se avisa al usuario que se envió la solicitud de retiro. Si levanta un error, se le avisa que el hash ingresado no es válido.