### PR TITLE
fix(withdrawals): handle failed transactions on lightning network wit…

### DIFF
--- a/app/commands/process_lightning_network_withdrawal.rb
+++ b/app/commands/process_lightning_network_withdrawal.rb
@@ -15,9 +15,12 @@ class ProcessLightningNetworkWithdrawal < PowerTypes::Command.new(:lightning_wit
 
   def process_payment
     ActiveRecord::Base.transaction do
-      @lightning_withdrawal.confirm!
-      RegisterLightningNetworkWithdrawalPayment.for(lightning_withdrawal: @lightning_withdrawal)
-      lightning_network_client.transaction(@lightning_withdrawal.invoice_hash)
+      response = lightning_network_client.transaction(@lightning_withdrawal.invoice_hash)
+      if response['payment_route']
+        @lightning_withdrawal.confirm!
+      else
+        @lightning_withdrawal.fail!
+      end
     end
   end
 

--- a/app/models/lightning_network_withdrawal.rb
+++ b/app/models/lightning_network_withdrawal.rb
@@ -3,7 +3,7 @@ class LightningNetworkWithdrawal < ApplicationRecord
   include AASM
   aasm column: 'state' do
     state :pending, initial: true
-    state :confirmed, :rejected
+    state :confirmed, :rejected, :failed
 
     event :confirm do
       transitions from: :pending, to: :confirmed
@@ -11,6 +11,10 @@ class LightningNetworkWithdrawal < ApplicationRecord
 
     event :reject do
       transitions from: :pending, to: :rejected
+    end
+
+    event :fail do
+      transitions from: :pending, to: :failed
     end
   end
 end

--- a/app/observers/lightning_network_withdrawal_observer.rb
+++ b/app/observers/lightning_network_withdrawal_observer.rb
@@ -1,7 +1,14 @@
 class LightningNetworkWithdrawalObserver < PowerTypes::Observer
   after_create :process_lightning_network_withdrawal
+  after_save :register_lightning_network_withdrawal_payment
 
   def process_lightning_network_withdrawal
     ProcessLightningNetworkWithdrawalJob.set(wait: 5.seconds).perform_later(object)
+  end
+
+  def register_lightning_network_withdrawal_payment
+    if object.state_changed?(from: :pending, to: :confirmed)
+      RegisterLightningNetworkWithdrawalPaymentJob.set(wait: 5.seconds).perform_later(object)
+    end
   end
 end

--- a/spec/commands/process_lightning_network_withdrawal_spec.rb
+++ b/spec/commands/process_lightning_network_withdrawal_spec.rb
@@ -8,10 +8,10 @@ describe ProcessLightningNetworkWithdrawal do
   let(:user) { create(:user) }
   let(:ledger_account) { create(:ledger_account, accountable: user) }
   let(:lightning_withdrawal) { create(:lightning_network_withdrawal, user_id: user.id) }
-
-  before do
-    allow_any_instance_of(LightningNetworkClient).to receive(:transaction)
-      .with(lightning_withdrawal.invoice_hash)
+  let(:payment_response) do
+    {
+      'payment_route' => payment_route
+    }
   end
 
   context 'without enough funds' do
@@ -25,23 +25,25 @@ describe ProcessLightningNetworkWithdrawal do
   context 'with enough funds' do
     before do
       create(:ledger_line, ledger_account: ledger_account, balance: -10000)
-      expect(RegisterLightningNetworkWithdrawalPayment).to receive(:for)
-        .with(lightning_withdrawal: lightning_withdrawal)
-        .and_return('success')
-    end
-    it 'memo and amount are correctly saved' do
-      perform(lightning_withdrawal: lightning_withdrawal)
-      expect { lightning_withdrawal.amount.to eq(10000) }
-      expect { lightning_withdrawal.memo.to eq('withdrawal memo') }
+      allow_any_instance_of(LightningNetworkClient).to receive(:transaction)
+        .with(lightning_withdrawal.invoice_hash)
+        .and_return(payment_response)
     end
 
-    it 'lightning withdrawal is confirmed' do
-      perform(lightning_withdrawal: lightning_withdrawal)
-      expect(lightning_withdrawal.state).to eq('confirmed')
+    context 'when transaction is successful' do
+      let(:payment_route) { 'some route' }
+      it 'lightning withdrawal is confirmed' do
+        perform(lightning_withdrawal: lightning_withdrawal)
+        expect(lightning_withdrawal.state).to eq('confirmed')
+      end
     end
 
-    it 'lightning withdrawal is registered in ledger' do
-      perform(lightning_withdrawal: lightning_withdrawal)
+    context 'when transaction is unsuccessful' do
+      let(:payment_route) { nil }
+      it 'lightning withdrawal is failed' do
+        perform(lightning_withdrawal: lightning_withdrawal)
+        expect(lightning_withdrawal.state).to eq('failed')
+      end
     end
   end
 end

--- a/spec/models/lightning_network_withdrawal_spec.rb
+++ b/spec/models/lightning_network_withdrawal_spec.rb
@@ -14,4 +14,8 @@ RSpec.describe LightningNetworkWithdrawal, type: :model do
   it 'changes state from pending to rejected' do
     expect(subject).to transition_from(:pending).to(:rejected).on_event(:reject)
   end
+
+  it 'changes state from pending to failed' do
+    expect(subject).to transition_from(:pending).to(:failed).on_event(:fail)
+  end
 end


### PR DESCRIPTION
…hdrawals

- Se cambia la lógica de registrar una línea contable cuando se ejecuta un retiro, para que el registro se haga en respuesta a un retiro confirmado.
- Se agrega el estado `failed` al modelo de retiros por Lightning, para manejar el caso en que la transacción del retiro no se realiza de manera correcta.