### PR TITLE
Fix register ln payments ledger

### DIFF
--- a/app/commands/register_lightning_network_withdrawal_payment.rb
+++ b/app/commands/register_lightning_network_withdrawal_payment.rb
@@ -2,7 +2,7 @@ class RegisterLightningNetworkWithdrawalPayment < PowerTypes::Command.new(:light
   PLATANUS_WALLET_ID = ENV.fetch('PLATANUS_WALLET_ID')
 
   def perform
-    return unless @lightning_withdrawal.confirmed?
+    return if withdrawal_not_confirmed? || allready_accounted?
 
     Ledger::Transfer.for(
       from: lightning_account,
@@ -14,6 +14,14 @@ class RegisterLightningNetworkWithdrawalPayment < PowerTypes::Command.new(:light
   end
 
   private
+
+  def withdrawal_not_confirmed?
+    !@lightning_withdrawal.confirmed?
+  end
+
+  def allready_accounted?
+    LedgerLine.where(accountable: @lightning_withdrawal).any?
+  end
 
   def debt_to_seller_account
     LedgerAccount.find_or_create_by!(

--- a/app/models/lightning_network_withdrawal.rb
+++ b/app/models/lightning_network_withdrawal.rb
@@ -1,6 +1,9 @@
 class LightningNetworkWithdrawal < ApplicationRecord
   include PowerTypes::Observable
   include AASM
+
+  belongs_to :user
+
   aasm column: 'state' do
     state :pending, initial: true
     state :confirmed, :rejected, :failed

--- a/app/observers/lightning_network_withdrawal_observer.rb
+++ b/app/observers/lightning_network_withdrawal_observer.rb
@@ -7,8 +7,6 @@ class LightningNetworkWithdrawalObserver < PowerTypes::Observer
   end
 
   def register_lightning_network_withdrawal_payment
-    if object.state_changed?(from: :pending, to: :confirmed)
-      RegisterLightningNetworkWithdrawalPaymentJob.set(wait: 5.seconds).perform_later(object)
-    end
+    RegisterLightningNetworkWithdrawalPaymentJob.set(wait: 5.seconds).perform_later(object)
   end
 end


### PR DESCRIPTION
A nivel del comando del registro del retiro se valida que no se dupliquen las `ledger_lines`.
Se hace redundante la validación de cambio de estado a `confirmed?` en el Job (que era lo que estaba fallando).