### PR TITLE
feat(user-products): add format to money displayed in the user products overview

### DIFF
--- a/app/views/user_products/_row.html.erb
+++ b/app/views/user_products/_row.html.erb
@@ -1,9 +1,23 @@
 <tr>
 	<td> <%= user_product.product_name %> </td>
-	<td> <%= user_product.price %> </td>
+  <td>
+    <%= number_to_currency(user_product.price,
+                           unit: '',
+                           format: '%n %u',
+                           negative_format: '-%n %u'
+                          )
+    %>
+  </td>
 	<td> <%= user_product.stock %> </td>
 	<td> <%= user_product.total_count %> </td>
-	<td> <%= user_product.total_satoshi %> </td>
+	<td>
+    <%= number_to_currency(user_product.total_satoshi,
+                             unit: '',
+                             format: '%n %u',
+                             negative_format: '-%n %u'
+                            )
+    %>
+  </td>
 	<td class="products-index__table-actions">
 		<button
 			type="button"

--- a/app/views/user_products/index.html.erb
+++ b/app/views/user_products/index.html.erb
@@ -41,13 +41,15 @@
           unit: 'Satoshis',
           format: '%n %u',
           negative_format: '-%n %u'
-        ) %></h4>
+        ) %>
+    </h4>
 		<h4 class="products-index__withdrawable-amount"> Monto disponible para retiro: <%= number_to_currency(
           @withdrawable_amount,
           unit: 'Satoshis',
           format: '%n %u',
           negative_format: '-%n %u'
-        ) %></h4>
+        ) %>
+    </h4>
 
 		<% if @user_products.length > 0 %>
 			<table class="products-index__table">


### PR DESCRIPTION
Agregué el formato adecuado a las cantidades de dinero mostrados en el overview de los productos del vendedor.

![image](https://user-images.githubusercontent.com/37163577/61408916-24b38a00-a8af-11e9-926f-228f6568690d.png)


