### PR TITLE
Feat/navbar menu

### DIFF
--- a/app/assets/stylesheets/navigation.scss
+++ b/app/assets/stylesheets/navigation.scss
@@ -10,7 +10,7 @@ $navbar-background-color: #fff;
   background-color: $navbar-background-color;
   padding: 8px 5px;
 
-  &__nav-title {
+  &__title {
     font-size: 24px;
     align-self: flex-start;
     color: $navbar-title-font;
@@ -20,33 +20,12 @@ $navbar-background-color: #fff;
     }
   }
 
-  &__nav-link {
+  &__link {
     font-size: 16px;
     margin-top: 2px;
 
-    &--balance {
-      color: $navbar-item-font;
-    }
-
-    &--buy {
-      color: $navbar-item-font;
-    }
-
-    &--home {
-      color: $navbar-item-font;
-    }
-
-    &--login {
+    &--right {
       margin-left: auto;
-      color: $navbar-item-font;
-    }
-
-    &--logout {
-      margin-left: auto;
-      color: $navbar-item-font;
-    }
-
-    &--products {
       color: $navbar-item-font;
     }
 
@@ -55,8 +34,8 @@ $navbar-background-color: #fff;
     }
   }
 
-  &__nav-link,
-  &__nav-title {
+  &__link,
+  &__title {
     padding-right: 10px;
     padding-left: 10px;
     border-radius: 10px;

--- a/app/assets/stylesheets/navigation.scss
+++ b/app/assets/stylesheets/navigation.scss
@@ -1,26 +1,38 @@
 $navbar-item-font: #5356dc;
-$navigation-background-color: #fff;
+$navbar-item-hover: #080a1a;
+$navbar-title-font: #10123f;
+$navbar-background-color: #fff;
 
-.navigation {
+.navbar {
   display: flex;
   flex-flow: row nowrap;
   align-items: center;
-  background-color: $navigation-background-color;
+  background-color: $navbar-background-color;
   padding: 8px 5px;
 
   &__nav-title {
+    font-size: 24px;
     align-self: flex-start;
-    margin-left: 4px;
+    color: $navbar-title-font;
+
+    &:hover {
+      text-decoration: none;
+    }
   }
 
-  &__nav-route {
+  &__nav-link {
     font-size: 16px;
-    padding-right: 10px;
-    padding-left: 10px;
-    border-radius: 10px;
+    margin-top: 2px;
+
+    &--balance {
+      color: $navbar-item-font;
+    }
+
+    &--buy {
+      color: $navbar-item-font;
+    }
 
     &--home {
-      margin-right: auto;
       color: $navbar-item-font;
     }
 
@@ -34,8 +46,20 @@ $navigation-background-color: #fff;
       color: $navbar-item-font;
     }
 
-    &:hover {
+    &--products {
       color: $navbar-item-font;
     }
+
+    &:hover {
+      color: $navbar-item-hover;
+    }
   }
+
+  &__nav-link,
+  &__nav-title {
+    padding-right: 10px;
+    padding-left: 10px;
+    border-radius: 10px;
+  }
+
 }

--- a/app/assets/stylesheets/registrations/_main.scss
+++ b/app/assets/stylesheets/registrations/_main.scss
@@ -42,8 +42,10 @@ $registration-form-width: 368px;
     width: $registration-form-width;
   }
 
+  &__register-link,
   &__sign-in-link,
-  &__sign-in-link:visited {
+  &__sign-in-link:visited,
+  &__register-link:visited {
     text-decoration: none;
     border-bottom: 1px dotted $registration-form-input-font;
     color: $registration-form-input-font;

--- a/app/assets/stylesheets/user_products/_index.scss
+++ b/app/assets/stylesheets/user_products/_index.scss
@@ -37,10 +37,6 @@ $products-index-table-actions-background: #acabfb;
     background-color: $products-index-action-button-background;
     padding: 5px 10px;
     border-radius: 5px;
-
-    &--withdraw {
-      background-color: $products-index-withdraw-action-button-background;
-    }
   }
 
   &__action,

--- a/app/views/ledger_accounts/index.html.erb
+++ b/app/views/ledger_accounts/index.html.erb
@@ -37,8 +37,6 @@
             class: 'balance-index__action balance-index__action--withdraw'
           } %>
         <% end %>
-
-        <%= link_to "Mis Productos", user_products_path, class: 'balance-index__action' %>
       </div>
     </div>
 

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -1,21 +1,34 @@
-<div class="navigation">
-  <h4 class= "navigation__nav-title"> Refreshments </h4>
-
-  <%= link_to "Home", root_path,
-    class: "navigation__nav-route navigation__nav-route--home",
+<div class="navbar">
+  <%= link_to "Refreshments", root_path,
+    class: "navbar__nav-title",
     data: { turbolinks: false }
   %>
 
   <% if user_signed_in? %>
+    <%= link_to "Cartola", user_balance_index_path,
+      class: 'navbar__nav-link navbar__nav-link--balance',
+      data: { turbolinks: false }
+    %>
+
+    <%= link_to "Productos", user_products_path,
+      class: 'navbar__nav-link navbar__nav-link--products',
+      data: { turbolinks: false }
+    %>
+
     <%= link_to "Cerrar sesión", destroy_user_session_path,
       method: :delete,
-      class: "navigation__nav-route navigation__nav-route--logout",
+      class: 'navbar__nav-link navbar__nav-link--logout',
       data: { turbolinks: false }
     %>
 
   <% else %>
+    <%= link_to "Catálogo de compra", buy_path,
+      class: 'navbar__nav-link navbar__nav-link--buy',
+      data: { turbolinks: false }
+    %>
+
     <%= link_to "Iniciar sesión", new_user_session_path,
-      class: "navigation__nav-route navigation__nav-route--login",
+      class: 'navbar__nav-link navbar__nav-link--login',
       data: { turbolinks: false }
     %>
   <% end %>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -1,34 +1,34 @@
 <div class="navbar">
   <%= link_to "Refreshments", root_path,
-    class: "navbar__nav-title",
+    class: "navbar__title",
     data: { turbolinks: false }
   %>
 
   <% if user_signed_in? %>
     <%= link_to "Cartola", user_balance_index_path,
-      class: 'navbar__nav-link navbar__nav-link--balance',
+      class: 'navbar__link',
       data: { turbolinks: false }
     %>
 
     <%= link_to "Productos", user_products_path,
-      class: 'navbar__nav-link navbar__nav-link--products',
+      class: 'navbar__link',
       data: { turbolinks: false }
     %>
 
     <%= link_to "Cerrar sesión", destroy_user_session_path,
       method: :delete,
-      class: 'navbar__nav-link navbar__nav-link--logout',
+      class: 'navbar__link navbar__link--right',
       data: { turbolinks: false }
     %>
 
   <% else %>
     <%= link_to "Catálogo de compra", buy_path,
-      class: 'navbar__nav-link navbar__nav-link--buy',
+      class: 'navbar__link navbar__link--buy',
       data: { turbolinks: false }
     %>
 
     <%= link_to "Iniciar sesión", new_user_session_path,
-      class: 'navbar__nav-link navbar__nav-link--login',
+      class: 'navbar__link navbar__link--right',
       data: { turbolinks: false }
     %>
   <% end %>

--- a/app/views/user_products/index.html.erb
+++ b/app/views/user_products/index.html.erb
@@ -2,14 +2,6 @@
   <%= render 'shared/navigation' %>
 
   <div id="products-index-table-container" class="products-index__table-container">
-
-    <div id="withdrawal-modal-holder" class="modal hide fade" role="dialog" aria-labelledby="basicModal" aria-hidden="true">
-      <div class="modal-dialog" role="document">
-        <div class="modal-content">
-        </div>
-      </div>
-    </div>
-
     <%- flash.each do |_, msg| -%>
       <%= content_tag :div, msg, class: 'alert alert-success' if msg.is_a?(String) %>
     <%- end -%>
@@ -18,19 +10,6 @@
       <h1 class="products-index__title"> Mis Productos </h1>
 
       <div class="products-index__header-actions">
-        <% if @withdrawable_amount > 0 %>
-          <%= link_to "Hacer retiro", new_user_lightning_network_withdrawal_path, {
-            remote: true,
-            'data-toggle' => "modal",
-            'data-target' => "#withdrawal-modal-holder",
-            class: 'products-index__action products-index__action--withdraw'
-          } %>
-        <% end %>
-
-        <%= link_to 'Cartola', user_balance_index_path,
-          class: 'products-index__action'
-        %>
-
         <%= link_to "Agregar producto", new_user_product_path,
           class: 'products-index__action',
           data: { turbolinks: false }

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -33,8 +33,7 @@
       <% end -%>
 
       <%= f.submit "Ingresar", class: 'registration-form__submit-button' %>
-
     <% end %>
-
+    <a href="<%= new_user_registration_path %>" class="registration-form-container__register-link"> ¿No tienes cuenta? ¡Regístrate! </a>
   <div>
 </div>


### PR DESCRIPTION
- La navbar ahora incluye los links a cartola, productos y catálogo de compra. Al apretar "Refreshments", el usuario será redirigido a la ruta `root` correspondiente. Además, se sacó la opción de retirar balance desde la vista `index` de `user_products`.
 
![image](https://user-images.githubusercontent.com/37163577/61650809-7d559f00-ac82-11e9-97b9-8ca66d7046da.png)
![image](https://user-images.githubusercontent.com/37163577/61651153-4af87180-ac83-11e9-8a0c-4da889684801.png)

- Removí el botón que redirigía a la vista `index` de `user_products` de la vista `index` de `ledger_accounts`.

![image](https://user-images.githubusercontent.com/37163577/61651006-f9e87d80-ac82-11e9-92fa-186a9586c11e.png)

- Agregué un link a registro de usuario a la vista `new` de `sessions` para el usuario.

![image](https://user-images.githubusercontent.com/37163577/61651238-7713f280-ac83-11e9-963f-3894336b400e.png)

