### PR TITLE
fix(user-product): use object-fit to retain image aspect ratio

### DIFF
--- a/app/assets/stylesheets/user_products/_index.scss
+++ b/app/assets/stylesheets/user_products/_index.scss
@@ -66,12 +66,9 @@ $products-index-table-actions-background: #acabfb;
 
   &__table-image {
     &--fixed-size {
-      width: 50%;
-      height: 50%;
-      min-width: 20%;
-      min-height: 20%;
-      max-width: 60px;
-      max-height: 60px;
+      width: 100px;
+      height: 60px;
+      object-fit: contain;
     }
   }
 


### PR DESCRIPTION
Se muestran miniaturas de los productos manteniendo su proporción.

![image](https://user-images.githubusercontent.com/17652944/61717130-7f753780-ad2e-11e9-948a-767fc914eb25.png)
