### PR TITLE
fix(sidekiq): temporarily reduce concurrency for sales with more than one product

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,5 +1,5 @@
 production:
-  :concurrency: 5
+  :concurrency: 1
 :queues:
   - default
   - ledger_transaction


### PR DESCRIPTION
Se reduce la concurrencia temporalmente para evitar el bug actual al momento de calcular el balance del usuario luego de compras por más de un producto.

![image](https://user-images.githubusercontent.com/17652944/61974962-ce80ce00-afb5-11e9-984e-450f80e4d80d.png)
