### PR TITLE
feat(user-product): add fee_rate

### DIFF
--- a/app/controllers/user_products_controller.rb
+++ b/app/controllers/user_products_controller.rb
@@ -38,7 +38,9 @@ class UserProductsController < ApplicationController
   private
 
   def permitted_params
-    params.require(:user_product).permit(:name, :price, :stock, :image, :category, :active)
+    params
+      .require(:user_product)
+      .permit(:name, :price, :stock, :image, :category, :fee_rate, :active)
   end
 
   def check_user_product

--- a/app/models/user_product.rb
+++ b/app/models/user_product.rb
@@ -1,6 +1,7 @@
 class UserProduct < ApplicationRecord
   validates :name, :price, :stock, :category, presence: true
   validates :price, :stock, numericality: { greater_than_or_equal_to: 0 }
+  validates :fee_rate, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 1 }
   validates :image, attached: true
 
   scope :active, -> { where(active: true) }
@@ -31,6 +32,7 @@ end
 #  updated_at :datetime         not null
 #  name       :string
 #  category   :integer          default("other"), not null
+#  fee_rate   :decimal(4, 3)    default(0.0), not null
 #
 # Indexes
 #

--- a/db/migrate/20190729144744_add_fee_rate_to_user_products.rb
+++ b/db/migrate/20190729144744_add_fee_rate_to_user_products.rb
@@ -1,0 +1,6 @@
+class AddFeeRateToUserProducts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :user_products, :fee_rate, :decimal, precision: 4, scale: 3, default: 0.0,
+                                                    null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_26_143449) do
+ActiveRecord::Schema.define(version: 2019_07_29_144744) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -130,6 +130,7 @@ ActiveRecord::Schema.define(version: 2019_07_26_143449) do
     t.datetime "updated_at", null: false
     t.string "name"
     t.integer "category", default: 2, null: false
+    t.decimal "fee_rate", precision: 4, scale: 3, default: "0.0", null: false
     t.index ["user_id"], name: "index_user_products_on_user_id"
   end
 


### PR DESCRIPTION
Se agrega el atributo `fee_rate` a `UserProduct`.

Los usuarios lo ingresarán a futuro como porcentaje hasta un decimal (ej. 1.2 %), por lo tanto se almacena en la base de datos como un decimal con `precision` 4 y `scale` 3 (siguiendo el ejemplo se almacenaría como 0.012).

Por default el valor de la comisión es 0 y se valida que el valor esté en el rango de 0 a 1.