### PR TITLE
bug(user-product): change image file input position property to relative

### DIFF
--- a/app/assets/stylesheets/user_products/_form.scss
+++ b/app/assets/stylesheets/user_products/_form.scss
@@ -92,7 +92,7 @@ $product-form-input-border-width: 1px;
       width: 1px;
       padding: 0;
       border: 0;
-      position: absolute;
+      position: relative;
       white-space: nowrap;
       overflow: hidden;
       clip: rect(0, 0, 0, 0);


### PR DESCRIPTION
Se modificó la propiedad `position` del modificador `product-form__input--image` de `absolute` a `relative` para cambiar encajar su posición con el formulario y así evitar que aparecieran dos scrollbar.