### PR TITLE
feat(catalogue): add refresh time to scrollbar positions

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -42,6 +42,12 @@ import product from './components/product.vue';
 import feedback from './components/feedback.vue';
 
 export default {
+  data() {
+    return {
+      inactiveTime: null,
+      refreshTime: 300000,
+    };
+  },
   components: {
     appResume,
     appInvoice,
@@ -67,9 +73,20 @@ export default {
     closeModal() {
       this.$store.commit('setStatus', false);
     },
+    checkInactivity() {
+      clearTimeout(this.inactiveTime);
+      this.inactiveTime = setTimeout(() => this.refreshScrollBar(), this.refreshTime);
+    },
+    refreshScrollBar() {
+      const categories = [...this.$el.querySelectorAll('.product-category')];
+      categories.forEach(category => {
+        category.scrollLeft = 0;
+      });
+    },
   },
   mounted() {
     this.$store.dispatch('getProducts');
+    this.$el.addEventListener('click', this.checkInactivity);
   },
 };
 </script>


### PR DESCRIPTION
Los scrollbar horizontales de cada categoría vuelven a sus posiciones originales (es decir, se muestran los primeros productos de cada categoría) tras 5 minutos desde el último `click` o `tap` que haya hecho el usuario sobre el DOM.

Esto es a través del método `checkInactivity()` que dispara el `Timeout` de nuevo ante cada evento de este tipo, cuidando de resetearlo si es que ya hay uno en curso.