### PR TITLE
Feat/order by fee

### DIFF
--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -1,6 +1,8 @@
 import Vue from 'vue/dist/vue.esm.js';
 import Vuex from 'vuex';
 
+import { shuffle } from 'lodash';
+
 import api from './api';
 
 const REFRESH_INTERVAL_TIME = 120000;
@@ -156,11 +158,17 @@ const store = new Vuex.Store({
   },
   getters: {
     productsAsArray: state => (Object.keys(state.products).map(key => ({ id: key, ...state.products[key] }))),
-    onSaleProducts: (state, getters) => (getters.productsAsArray
-      .filter(product => product.for_sale))
-      .sort((a, b) => a.name.localeCompare(b.name)),
-    groupByCategory: (state, getters) => keyword => (getters.onSaleProducts
-      .filter(product => product.category === keyword)
+    onSaleProducts: (state, getters) => (
+      getters.productsAsArray.filter(product => product.for_sale)
+    ),
+    sortRandom: (state, getters) => (
+      shuffle(getters.onSaleProducts)
+    ),
+    sortByFee: (state, getters) => (
+      getters.sortRandom.sort((a, b) => b.fee_rate - a.fee_rate)
+    ),
+    groupByCategory: (state, getters) => keyword => (
+      getters.sortByFee.filter(product => product.category === keyword)
     ),
     totalAmount: (state, getters) => (
       getters.onSaleProducts.reduce((acc, product) => acc + product.amount, 0)

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -5,7 +5,7 @@ import { shuffle } from 'lodash';
 
 import api from './api';
 
-const REFRESH_INTERVAL_TIME = 120000;
+const REFRESH_INTERVAL_TIME = 300000;
 
 Vue.use(Vuex);
 

--- a/app/serializers/product_serializer.rb
+++ b/app/serializers/product_serializer.rb
@@ -1,7 +1,7 @@
 class ProductSerializer < ActiveModel::Serializer
   include Rails.application.routes.url_helpers
 
-  attributes :id, :name, :stock, :price, :image_url, :for_sale, :category
+  attributes :id, :name, :stock, :price, :image_url, :for_sale, :category, :fee_rate
 
   def for_sale
     object.active && object.stock.positive?

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@xkeshi/vue-qrcode": "^1.0.0",
     "add": "^2.0.6",
     "axios": "^0.18.0",
+    "lodash.shuffle": "^4.2.0",
     "vue": "^2.5.16",
     "vue-clipboard2": "^0.2.1",
     "vue-flash-message": "^0.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3679,6 +3679,11 @@ lodash.mergewith@^4.6.0:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz#639057e726c3afbdb3e7d42741caa8d6e4335927"
 
+lodash.shuffle@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.shuffle/-/lodash.shuffle-4.2.0.tgz#145b5053cf875f6f5c2a33f48b6e9948c6ec7b4b"
+  integrity sha1-FFtQU8+HX29cKjP0i26ZSMbse0s=
+
 lodash.tail@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"


### PR DESCRIPTION
Se añadió el método `shuffle` del paquete `lodash` a `yarn.lock`, con el que se hace un re-arreglo aleatorio de la lista de productos que aparecen en el catálogo (a través del getter `sortRandom`). 

Luego, el arreglo es ordenado por el getter `sortByFee` de acuerdo al porcentaje de comisión que ofrece cada producto, separado por categoría. 

Por otra parte, se modificó el `serializer` de la api para los productos para entregara el `fee_rate` de estos.

Por último, se aumtentó el intervalo de actualización de los productos 2 a 5 minutos. 