### PR TITLE
Bug/product refresh

### DIFF
--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -76,8 +76,8 @@ export default {
     checkInactivity() {
       clearTimeout(this.inactiveTime);
       this.inactiveTime = setTimeout(() => {
+        this.$store.dispatch('refreshProducts');
         this.refreshScrollBar();
-        this.refreshProducts();
       }, this.refreshTime);
     },
     refreshScrollBar() {
@@ -85,10 +85,6 @@ export default {
       categories.forEach(category => {
         category.scrollLeft = 0;
       });
-    },
-    refreshProducts() {
-      this.$store.commit('setShuffled', false);
-      this.$store.dispatch('getProducts');
     },
   },
   mounted() {

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -75,13 +75,20 @@ export default {
     },
     checkInactivity() {
       clearTimeout(this.inactiveTime);
-      this.inactiveTime = setTimeout(() => this.refreshScrollBar(), this.refreshTime);
+      this.inactiveTime = setTimeout(() => {
+        this.refreshScrollBar();
+        this.refreshProducts();
+      }, this.refreshTime);
     },
     refreshScrollBar() {
       const categories = [...this.$el.querySelectorAll('.product-category')];
       categories.forEach(category => {
         category.scrollLeft = 0;
       });
+    },
+    refreshProducts() {
+      this.$store.commit('setShuffled', false);
+      this.$store.dispatch('getProducts');
     },
   },
   mounted() {

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -87,7 +87,9 @@ export default {
   mounted() {
     this.$store.dispatch('getProducts');
     this.$store.dispatch('getFeeBalance');
-    this.$el.addEventListener('click', this.checkInactivity);
+    ['click', 'mousedown', 'touchmove'].forEach(
+      event => this.$el.addEventListener(event, this.checkInactivity)
+    );
   },
 };
 </script>

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -170,15 +170,18 @@ const store = new Vuex.Store({
     ),
     sortRandom: (state, getters) => {
       if (state.shuffled) {
-        const order = state.shuffledIndexes;
-        const reShuffledProducts = getters.onSaleProducts.sort(
-          (a, b) => order.indexOf(a.id) - order.indexOf(b.id)
-        );
-
-        return reShuffledProducts;
+        return getters.restorePreviousOrder;
       }
 
       return shuffle(getters.onSaleProducts);
+    },
+    restorePreviousOrder: (state, getters) => {
+      const previousOrder = state.shuffledIndexes;
+      const reOrderedProducts = getters.onSaleProducts.sort(
+        (a, b) => previousOrder.indexOf(a.id) - previousOrder.indexOf(b.id)
+      );
+
+      return reOrderedProducts;
     },
     sortByFee: (state, getters) => (
       getters.sortRandom.sort((a, b) => b.feeRate - a.feeRate)

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -7,8 +7,6 @@ import productApi from '../api/products';
 import invoiceApi from '../api/invoices';
 import statisticsApi from '../api/statistics';
 
-const REFRESH_INTERVAL_TIME = 300000;
-
 Vue.use(Vuex);
 
 const store = new Vuex.Store({
@@ -20,7 +18,6 @@ const store = new Vuex.Store({
     loading: false,
     actionMessage: '',
     actionProductId: null,
-    intervalId: null,
     gif: null,
 <<<<<<< HEAD
     feeBalance: 0,
@@ -58,9 +55,6 @@ const store = new Vuex.Store({
     setLoading: (state, payload) => {
       state.loading = payload;
     },
-    setIntervalId: (state, payload) => {
-      state.intervalId = payload;
-    },
     setGif: (state, payload) => {
       state.gif = payload;
     },
@@ -83,7 +77,6 @@ const store = new Vuex.Store({
           return acc;
         }, {});
         context.commit('setProducts', products);
-        context.dispatch('startGetProductsInterval');
         if (!context.state.shuffled) {
           context.dispatch('getShuffledIndexes');
         }
@@ -99,7 +92,6 @@ const store = new Vuex.Store({
       context.commit('setActionProduct', payload.id);
       context.commit('setActionMessage', 'decrement');
       context.commit('setProduct', { ...payload, amount });
-      context.dispatch('startGetProductsInterval');
       context.dispatch('buy');
     },
     incrementProduct: (context, payload) => {
@@ -110,7 +102,6 @@ const store = new Vuex.Store({
       if (payload.stock > payload.amount) {
         context.commit('setProduct', { ...payload, amount: payload.amount + 1 });
         context.commit('setActionMessage', 'increment');
-        context.dispatch('stopGetProductsInterval');
         context.dispatch('buy');
       } else {
         context.commit('setActionMessage', 'maxStock');
@@ -144,7 +135,6 @@ const store = new Vuex.Store({
         context.commit('setProduct', { ...product, amount: 0 });
       });
       context.commit('setLoading', false);
-      context.dispatch('startGetProductsInterval');
     },
     cleanInvoice: context => {
       context.commit('setInvoice', {});
@@ -160,20 +150,6 @@ const store = new Vuex.Store({
     },
     setLoading: (context, payload) => {
       context.commit('setLoading', payload);
-    },
-    startGetProductsInterval: context => {
-      if (context.getters.totalAmount === 0 && !context.state.intervalId) {
-        const interval = setInterval(() => {
-          context.dispatch('getProducts');
-        }, REFRESH_INTERVAL_TIME);
-        context.commit('setIntervalId', interval);
-      }
-    },
-    stopGetProductsInterval: context => {
-      if (context.state.intervalId) {
-        clearInterval(context.state.intervalId);
-        context.commit('setIntervalId', null);
-      }
     },
     getGif: context => {
       invoiceApi.getGif().then((response) => {

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -158,6 +158,10 @@ const store = new Vuex.Store({
         context.commit('setFeeBalance', response.feeBalance);
       });
     },
+    refreshProducts: context => {
+      context.commit('setShuffled', false);
+      context.dispatch('getProducts');
+    },
   },
   getters: {
     productsAsArray: state => (Object.keys(state.products).map(key => ({ id: key, ...state.products[key] }))),

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -19,12 +19,9 @@ const store = new Vuex.Store({
     actionMessage: '',
     actionProductId: null,
     gif: null,
-<<<<<<< HEAD
     feeBalance: 0,
-=======
     shuffled: false,
     shuffledIndexes: {},
->>>>>>> a505ae0... bug(catalogue): fix constant product order randomization when updating cart
   },
   mutations: {
     setProduct: (state, payload) => {
@@ -78,11 +75,11 @@ const store = new Vuex.Store({
         }, {});
         context.commit('setProducts', products);
         if (!context.state.shuffled) {
-          context.dispatch('getShuffledIndexes');
+          context.dispatch('shuffleIndexes');
         }
       });
     },
-    getShuffledIndexes: context => {
+    shuffleIndexes: context => {
       const shuffledIndexes = shuffle(context.state.products).map(product => product.id);
       context.commit('setShuffledIndexes', shuffledIndexes);
       context.commit('setShuffled', true);


### PR DESCRIPTION
Se soluciona el problema de que los productos volvían a ser ordenados de manera aleatoria cada vez que se agregaba/quitaba un producto del carrito al guardar el "orden" del arreglo la primera vez que es reordenado en el estado `shuffledIndexes` como:

```javascript
shuffledIndexes : {
  0: 5,
  1: 45,
  2: 12,
  ...
  n: m
  }
```
En donde cada valor guardado es el ID de un producto.

 Luego, cada vez que se manda un request a la api por los productos, el arreglo resultante se reordena con respecto a las posiciones guardadas en `shuffledIndexes`.

Por otro lado, este "orden" guardado se reseteará después de un cierto tiempo de inactividad por parte del usuario, vaciando el carrito y devolviendo las posiciones de todos los scrollbars al original al mismo tiempo en que se actualiza la información pertinente de los productos.