### PR TITLE
 feat(): display fee balance and purchase contribution

### DIFF
--- a/app/assets/stylesheets/refreshments/_modal.scss
+++ b/app/assets/stylesheets/refreshments/_modal.scss
@@ -26,15 +26,26 @@ $modal-backgorund-color: #419a41;
     font-size: 45px;
     color: #fff;
     text-align: center;
-    height: 25%;
+    height: 15%;
   }
 
-  &__body {
+  &__gif {
     position: relative;
     padding: 20px;
     height: 65%;
     display: flex;
     justify-content: center;
+  }
+
+  &__detail {
+    font-size: 26px;
+    color: #fff;
+    display: flex;
+    justify-content: center;
+
+    &--fee-balance {
+      font-weight: bold;
+    }
   }
 }
 

--- a/app/commands/get_fee_balance.rb
+++ b/app/commands/get_fee_balance.rb
@@ -1,0 +1,15 @@
+class GetFeeBalance < PowerTypes::Command.new
+  def perform
+    fee_balance
+  end
+
+  private
+
+  def fee_balance
+    -business_user.available_funds.balance
+  end
+
+  def business_user
+    User.find(ENV.fetch("BUSINESS_USER_ID"))
+  end
+end

--- a/app/controllers/api/v1/invoices_controller.rb
+++ b/app/controllers/api/v1/invoices_controller.rb
@@ -3,7 +3,7 @@ class Api::V1::InvoicesController < Api::V1::BaseController
     shopping_cart_items
     invoice = CreateInvoice.for(shopping_cart_items: shopping_cart_items)
 
-    respond_with invoice: invoice
+    render json: invoice
   end
 
   def status

--- a/app/controllers/api/v1/statistics_controller.rb
+++ b/app/controllers/api/v1/statistics_controller.rb
@@ -1,0 +1,5 @@
+class Api::V1::StatisticsController < Api::V1::BaseController
+  def fee_balance
+    respond_with fee_balance: GetFeeBalance.for
+  end
+end

--- a/app/javascript/api/statistics.js
+++ b/app/javascript/api/statistics.js
@@ -1,0 +1,12 @@
+import api from './api';
+
+export default {
+  feeBalance() {
+    const path = '/api/v1/statistics/fee_balance';
+
+    return api({
+      method: 'get',
+      url: path,
+    });
+  },
+};

--- a/app/javascript/app.vue
+++ b/app/javascript/app.vue
@@ -86,6 +86,7 @@ export default {
   },
   mounted() {
     this.$store.dispatch('getProducts');
+    this.$store.dispatch('getFeeBalance');
     this.$el.addEventListener('click', this.checkInactivity);
   },
 };

--- a/app/javascript/components/app-invoice.vue
+++ b/app/javascript/components/app-invoice.vue
@@ -97,11 +97,13 @@ export default {
       'cleanCart',
       'cleanInvoice',
       'updateInvoiceSettled',
+      'getFeeBalance',
     ]),
     close() {
       this.cleanInvoice();
       this.cleanCart();
       this.toggleResume();
+      this.getFeeBalance();
     },
     copyPaymentRequest() {
       this.$copyText(this.invoice.paymentRequest).then(e => {

--- a/app/javascript/components/feedback.vue
+++ b/app/javascript/components/feedback.vue
@@ -19,12 +19,18 @@
           </slot>
         </header>
         <section
-          class="feedback-modal__body"
+          class="feedback-modal__gif"
           id="modalDescription"
         >
-          <slot name="body">
+          <slot name="gif">
             <img :src="gif">
           </slot>
+        </section>
+        <section class="feedback-modal__detail">
+          Con tu compra aportaste {{ invoice.feeAmount }} SAT para el asado
+        </section>
+        <section class="feedback-modal__detail feedback-modal__detail--fee-balance">
+          Acumulados: {{ updatedFeeBalance }} SAT
         </section>
       </div>
     </div>
@@ -41,7 +47,12 @@ export default {
     ...mapState([
       'gif',
       'status',
+      'invoice',
+      'feeBalance',
     ]),
+    updatedFeeBalance() {
+      return this.feeBalance + this.invoice.feeAmount || 0;
+    },
   },
   methods: {
     ...mapActions(['getGif']),

--- a/app/javascript/store/index.js
+++ b/app/javascript/store/index.js
@@ -5,6 +5,7 @@ import { shuffle } from 'lodash';
 
 import productApi from '../api/products';
 import invoiceApi from '../api/invoices';
+import statisticsApi from '../api/statistics';
 
 const REFRESH_INTERVAL_TIME = 300000;
 
@@ -21,6 +22,7 @@ const store = new Vuex.Store({
     actionProductId: null,
     intervalId: null,
     gif: null,
+    feeBalance: 0,
   },
   mutations: {
     setProduct: (state, payload) => {
@@ -56,6 +58,9 @@ const store = new Vuex.Store({
     },
     setGif: (state, payload) => {
       state.gif = payload;
+    },
+    setFeeBalance: (state, payload) => {
+      state.feeBalance = payload;
     },
   },
   actions: {
@@ -154,6 +159,11 @@ const store = new Vuex.Store({
     getGif: context => {
       invoiceApi.getGif().then((response) => {
         context.commit('setGif', response.gifUrl.gifUrl);
+      });
+    },
+    getFeeBalance: context => {
+      statisticsApi.feeBalance().then((response) => {
+        context.commit('setFeeBalance', response.feeBalance);
       });
     },
   },

--- a/app/serializers/invoice_serializer.rb
+++ b/app/serializers/invoice_serializer.rb
@@ -1,3 +1,7 @@
 class InvoiceSerializer < ActiveModel::Serializer
-  attributes :id, :amount, :clp, :payment_request, :r_hash, :memo, :settled
+  attributes :id, :amount, :fee_amount, :clp, :payment_request, :r_hash, :memo, :settled
+
+  def fee_amount
+    object.invoice_products.sum(&:product_fee)
+  end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,10 +4,12 @@ Rails.application.routes.draw do
   scope path: '/api' do
     api_version(module: 'Api::V1', path: { value: 'v1' }, defaults: { format: 'json' }) do
       resources :products, only: [:index, :show]
-      get '/satoshi_price', to: 'prices#satoshi_price'
       resources :invoices, only: [:create]
       get 'invoices/status/:r_hash', to: 'invoices#status'
+      get '/satoshi_price', to: 'prices#satoshi_price'
       get '/gif', to: 'gifs#show_random'
+
+      get '/statistics/fee_balance'
     end
   end
   devise_for :admin_users, ActiveAdmin::Devise.config

--- a/spec/commands/get_fee_balance_spec.rb
+++ b/spec/commands/get_fee_balance_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+describe GetFeeBalance do
+  def perform
+    described_class.for
+  end
+
+  let(:balance) { -145000 }
+  let(:ledger_account) { create(:user_ledger_account, balance: balance) }
+
+  before do
+    allow(ENV).to receive(:fetch)
+      .with('BUSINESS_USER_ID').and_return(ledger_account.accountable_id)
+  end
+
+  it 'returns expected balance' do
+    expect(perform).to eq(145000)
+  end
+end

--- a/spec/controllers/api/v1/statistics_controller_spec.rb
+++ b/spec/controllers/api/v1/statistics_controller_spec.rb
@@ -1,0 +1,14 @@
+require 'rails_helper'
+
+RSpec.describe Api::V1::StatisticsController, type: :controller do
+  describe "GET #fee_balance" do
+    before do
+      allow(GetFeeBalance).to receive(:for).and_return(145000)
+    end
+
+    it 'calls GetFeeBalance command' do
+      get :fee_balance
+      expect(GetFeeBalance).to have_received(:for)
+    end
+  end
+end

--- a/spec/factories/ledger_accounts.rb
+++ b/spec/factories/ledger_accounts.rb
@@ -18,5 +18,11 @@ FactoryBot.define do
         )
       end
     end
+
+    factory :user_ledger_account do
+      association :accountable, factory: :user
+      category { 'available_funds' }
+      balance { -1000 }
+    end
   end
 end


### PR DESCRIPTION
Se muestra lo recaudado en comisiones en el mensaje de compra exitosa, además del aporte en satoshis de la compra.

- Se agrega un controlador de estadísticas en la api. Actualmente sólo entrega el fondo disponible de comisiones recaudadas (`fee_balance`) y a futuro la idea es que maneje otras estadísticas.
-  Se calcula el monto a pagar en comisiones por `invoice`.
- Dado que la compra exitosa se determina mediante un polling, en el mensaje de éxito se muestra lo pagado en comisiones de la compra y el balance actual calculado. Luego, (al resetear el invoice resume) se actualiza el valor de `feeBalance` en el front (para evitar su cálculo cada vez que se genera un invoice).
<img src="https://user-images.githubusercontent.com/17652944/62650205-4f2fba80-b924-11e9-9da1-afddbfc6ef50.png" width="400">