### PR TITLE
refactor(catalogue): change ratio of the resume sidebar compared to products display area

### DIFF
--- a/app/assets/stylesheets/refreshments.scss
+++ b/app/assets/stylesheets/refreshments.scss
@@ -30,7 +30,7 @@ $bg-color: #fff;
   &__container {
     background: $bg-color;
     border-left: 1px solid $border-color;
-    width: 40vw;
+    width: 30vw;
     padding: 10px 0;
     height: 100vh;
     overflow-y: scroll;

--- a/app/assets/stylesheets/refreshments/_product.scss
+++ b/app/assets/stylesheets/refreshments/_product.scss
@@ -10,7 +10,7 @@ $shadow-color: #10131e;
   flex-direction: column;
   align-content: space-around;
   justify-content: space-around;
-  width: 70%;
+  width: 70vw;
 }
 
 .product-category {

--- a/app/assets/stylesheets/refreshments/_product.scss
+++ b/app/assets/stylesheets/refreshments/_product.scss
@@ -10,7 +10,7 @@ $shadow-color: #10131e;
   flex-direction: column;
   align-content: space-around;
   justify-content: space-around;
-  width: 60%;
+  width: 70%;
 }
 
 .product-category {


### PR DESCRIPTION
Cambié el ratio en que se ven los productos v/s el resumen que se muestra en la derecha (previamente este último tomaba el 40% de la pantalla/ventana).

![image](https://user-images.githubusercontent.com/37163577/62668224-0fcf9100-b959-11e9-90d2-85ec632c7e6d.png)
