### PR TITLE
feat(ui/resume): use ellipsis to hide overflow in names

### DIFF
--- a/app/assets/stylesheets/refreshments/_resume.scss
+++ b/app/assets/stylesheets/refreshments/_resume.scss
@@ -46,7 +46,7 @@ $default-color: #676775;
 
   &__product {
     display: flex;
-    padding: 5px 0;
+    padding: 0;
     text-align: left;
     height: 28px;
     color: $default-color;
@@ -67,7 +67,10 @@ $default-color: #676775;
   }
 
   &__name {
-    flex: 60% 1 1;
+    flex: 100% 1 1;
+    white-space: nowrap;
+    overflow-x: hidden;
+    text-overflow: ellipsis;
   }
 
   &__total {


### PR DESCRIPTION
Se mejora la forma en la que se despliegan los productos en el resumen de la compra, para que se vean cortados si se pasan del ancho. Además se elimina un padding que hacía que al arreglar el tema anterior, quedaran desalineadas verticalmente las columnas.

|Antes|Después|
|-|-|
|![image](https://user-images.githubusercontent.com/11674283/65986393-25919c00-e45a-11e9-92bb-0b22cef0c126.png)|![image](https://user-images.githubusercontent.com/11674283/65986442-40fca700-e45a-11e9-9f08-724b4c555fed.png)|