### PR TITLE
Feat/slack notify seller of debt

### DIFF
--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -6,4 +6,11 @@ class Api::V1::ProductsController < Api::V1::BaseController
   def show
     render json: Product.find(params[:id])
   end
+
+  def get_seller
+    puts 'ENTRO ACA!!!!'
+    puts params[:product_id]
+
+    render json: Product.find(params[:product_id]).user
+  end
 end

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -7,7 +7,13 @@ class Api::V1::ProductsController < Api::V1::BaseController
     render json: Product.find(params[:id])
   end
 
-  def get_seller
-    render json: Product.find(params[:product_id]).user
+  def seller
+    render json: product.user
+  end
+
+  private
+
+  def product
+    @product ||= Product.find(params[:product_id] || params[:id])
   end
 end

--- a/app/controllers/api/v1/products_controller.rb
+++ b/app/controllers/api/v1/products_controller.rb
@@ -8,9 +8,6 @@ class Api::V1::ProductsController < Api::V1::BaseController
   end
 
   def get_seller
-    puts 'ENTRO ACA!!!!'
-    puts params[:product_id]
-
     render json: Product.find(params[:product_id]).user
   end
 end

--- a/app/controllers/api/v1/slack_controller.rb
+++ b/app/controllers/api/v1/slack_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::SlackController < Api::V1::BaseController
   end
 
   def notify_user
-    slack.notify_user(params[:user_name], params[:user_id], params[:message])
+    slack.notify_user(params[:user_id], params[:message])
   end
 
   private
@@ -28,7 +28,7 @@ class Api::V1::SlackController < Api::V1::BaseController
   end
 
   def notify_params
-    params.permit(:user_name, :user_id, :message)
+    params.permit(:user_id, :message)
   end
 
   def slack

--- a/app/controllers/api/v1/slack_controller.rb
+++ b/app/controllers/api/v1/slack_controller.rb
@@ -12,7 +12,7 @@ class Api::V1::SlackController < Api::V1::BaseController
   end
 
   def notify_user
-    slack.notify_user(params[:user_name], params[:user_id])
+    slack.notify_user(params[:user_name], params[:user_id], params[:message])
   end
 
   private
@@ -28,7 +28,7 @@ class Api::V1::SlackController < Api::V1::BaseController
   end
 
   def notify_params
-    params.permit(:user_name, :user_id)
+    params.permit(:user_name, :user_id, :message)
   end
 
   def slack

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,6 +25,6 @@ class ApplicationController < ActionController::Base
   protected
 
   def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :slack_user])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,5 +26,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name, :slack_user])
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name, :slack_user, :email])
   end
 end

--- a/app/javascript/api/invoices.js
+++ b/app/javascript/api/invoices.js
@@ -56,17 +56,17 @@ export default {
       url: path,
     });
   },
-  notifyUser(userName, userId, message) {
+  notifyUser(userId, message) {
     const path = 'api/v1/slack';
 
     return api({
       method: 'post',
       url: path,
-      data: { userName, userId, message },
+      data: { userId, message },
     });
   },
-  getSeller(product) {
-    const path = `api/v1/products/${product.id}/get_seller`;
+  seller(product) {
+    const path = `api/v1/products/${product.id}/seller`;
 
     return api({
       method: 'get',

--- a/app/javascript/api/invoices.js
+++ b/app/javascript/api/invoices.js
@@ -65,4 +65,12 @@ export default {
       data: { userName, userId },
     });
   },
+  getSeller(product) {
+    const path = `api/v1/products/${product.id}/get_seller`;
+
+    return api({
+      method: 'get',
+      url: path,
+    });
+  },
 };

--- a/app/javascript/api/invoices.js
+++ b/app/javascript/api/invoices.js
@@ -56,13 +56,13 @@ export default {
       url: path,
     });
   },
-  notifyUser(userName, userId) {
+  notifyUser(userName, userId, message) {
     const path = 'api/v1/slack';
 
     return api({
       method: 'post',
       url: path,
-      data: { userName, userId },
+      data: { userName, userId, message },
     });
   },
   getSeller(product) {

--- a/app/javascript/components/app-invoice.vue
+++ b/app/javascript/components/app-invoice.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="invoice">
-    <!-- <errorNotification v-if="!loading && invoice.paymentRequest" /> -->
-    <errorNotification />
+    <errorNotification v-if="!loading && invoice.paymentRequest" />
     <div
       class="invoice__info"
       v-if="totalPrice > 0"

--- a/app/javascript/components/app-invoice.vue
+++ b/app/javascript/components/app-invoice.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="invoice">
-    <errorNotification v-if="!loading && invoice.paymentRequest" />
+    <!-- <errorNotification v-if="!loading && invoice.paymentRequest" /> -->
+    <errorNotification />
     <div
       class="invoice__info"
       v-if="totalPrice > 0"

--- a/app/javascript/components/payment-error-button.vue
+++ b/app/javascript/components/payment-error-button.vue
@@ -140,8 +140,9 @@ export default {
       this.showNameTextBox = false;
       this.showDebtFinalMessage = true;
       const products = this.cartProductsToReqFormat();
+      const debtor = this.message.displayNameNormalized;
       invoiceApi.createDebtProduct({
-        'debtor': this.message.displayNameNormalized,
+        'debtor': debtor,
         'products': products,
       });
       const cart = this.products.filter(product => product.amount > 0);
@@ -163,13 +164,14 @@ export default {
       return invoiceApi.getSlackUsers();
     },
     notifySellersOfDebt(products) {
-      const message = `${this.message.displayNameNormalized} acaba de fiar un producto tuyo!`;
+      const debtor = this.message.displayNameNormalized;
+      const message = `${debtor} acaba de fiar un producto tuyo!`;
       products.forEach(prod => {
-        invoiceApi.getSeller(prod).then((seller) => {
-          const messageToDebtor = `${this.message.displayNameNormalized}, acabas de fiar un producto de ${seller.user.name}`
-          invoiceApi.notifyUser(this.message.displayNameNormalized, this.message.id, messageToDebtor);
+        invoiceApi.seller(prod).then((seller) => {
+          const messageToDebtor = `${debtor}, acabas de fiar un producto de ${seller.user.name}`;
+          invoiceApi.notifyUser(this.message.id, messageToDebtor);
           if (seller.user.slackUser) {
-            invoiceApi.notifyUser(this.message.displayNameNormalized, seller.user.slackUser, message);
+            invoiceApi.notifyUser(seller.user.slackUser, message);
           }
         });
       });

--- a/app/javascript/components/payment-error-button.vue
+++ b/app/javascript/components/payment-error-button.vue
@@ -144,8 +144,10 @@ export default {
         'debtor': this.message.displayNameNormalized,
         'products': products,
       });
-      //invoiceApi.notifyUser(this.message.displayNameNormalized, this.message.id);
-      this.notifySellersOfDebt(this.products.filter(product => product.amount > 0));
+      const cart = this.products.filter(product => product.amount > 0);
+      if (cart) {
+        this.notifySellersOfDebt(cart);
+      }
     },
     cartProductsToReqFormat() {
       const productsArray = this.products.filter(product => product.amount > 0);
@@ -161,9 +163,14 @@ export default {
       return invoiceApi.getSlackUsers();
     },
     notifySellersOfDebt(products) {
+      const message = `${this.message.displayNameNormalized} acaba de fiar un producto tuyo!`;
       products.forEach(prod => {
         invoiceApi.getSeller(prod).then((seller) => {
-          invoiceApi.notifyUser(this.message.displayNameNormalized, seller.user.slackUser);
+          const messageToDebtor = `${this.message.displayNameNormalized}, acabas de fiar un producto de ${seller.user.name}`
+          invoiceApi.notifyUser(this.message.displayNameNormalized, this.message.id, messageToDebtor);
+          if (seller.user.slackUser) {
+            invoiceApi.notifyUser(this.message.displayNameNormalized, seller.user.slackUser, message);
+          }
         });
       });
     },

--- a/app/javascript/components/payment-error-button.vue
+++ b/app/javascript/components/payment-error-button.vue
@@ -144,7 +144,8 @@ export default {
         'debtor': this.message.displayNameNormalized,
         'products': products,
       });
-      invoiceApi.notifyUser(this.message.displayNameNormalized, this.message.id);
+      //invoiceApi.notifyUser(this.message.displayNameNormalized, this.message.id);
+      this.notifySellersOfDebt(this.products.filter(product => product.amount > 0));
     },
     cartProductsToReqFormat() {
       const productsArray = this.products.filter(product => product.amount > 0);
@@ -158,6 +159,13 @@ export default {
     },
     getUsers() {
       return invoiceApi.getSlackUsers();
+    },
+    notifySellersOfDebt(products) {
+      products.forEach(prod => {
+        invoiceApi.getSeller(prod).then((seller) => {
+          invoiceApi.notifyUser(this.message.displayNameNormalized, seller.user.slackUser);
+        });
+      });
     },
   },
   mounted() {

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -53,6 +53,7 @@ end
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
 #  name                   :string           not null
+#  slack_user             :string           default("")
 #
 # Indexes
 #

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,0 +1,3 @@
+class UserSerializer < ActiveModel::Serializer
+  attributes :id, :name, :slack_user
+end

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -15,11 +15,11 @@ class SlackService
     all_members
   end
 
-  def  notify_user(user_name, user_id)
+  def  notify_user(user_name, user_id, message)
     client.chat_postMessage(
       channel: user_id,
       as_user: true,
-      text: "#{user_name}, fiaste un producto!"
+      text: message
     )
   end
 

--- a/app/services/slack_service.rb
+++ b/app/services/slack_service.rb
@@ -15,7 +15,7 @@ class SlackService
     all_members
   end
 
-  def  notify_user(user_name, user_id, message)
+  def  notify_user(user_id, message)
     client.chat_postMessage(
       channel: user_id,
       as_user: true,

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -20,6 +20,11 @@
       data: { turbolinks: false }
     %>
 
+    <%= link_to "Editar Perfil", edit_user_registration_path,
+      class: 'navbar__link',
+      data: { turbolinks: false }
+    %>
+
     <%= link_to "Cerrar sesión", destroy_user_session_path,
       method: :delete,
       class: 'navbar__link navbar__link--right',

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -8,6 +8,12 @@
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
+  <div class="field">
+    <%= f.label :slack_user %><br />
+    <%= f.text_field :slack_user, autofocus: true, autocomplete: "Id de Slack" %>
+  </div>
+
+
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
     <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
   <% end %>
@@ -35,6 +41,7 @@
     <%= f.submit "Update" %>
   </div>
 <% end %>
+
 
 <h3>Cancel my account</h3>
 

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -30,6 +30,11 @@
         <%= f.password_field :password_confirmation, class: 'registration-form__input' %>
       </div>
 
+      <div class="registration-form__field">
+        <%= f.label :slack_user, 'Tu Id de usuario de Slack', class: 'registration-form__label' %>
+        <%= f.text_field :slack_user, autofocus: true, class: 'registration-form__input' %>
+      </div>
+
       <%= f.submit "Registrar", class: 'registration-form__submit-button' %>
     <% end %>
     <a href="<%= new_user_session_path %>" class="registration-form-container__sign-in-link"> Ya tengo cuenta </a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,10 +3,9 @@ Rails.application.routes.draw do
   get 'buy', to: 'pages#buy'
   scope path: '/api' do
     api_version(module: 'Api::V1', path: { value: 'v1' }, defaults: { format: 'json' }) do
-      # resources :products, only: [:index, :show]
       resources :invoices, only: [:create]
       resources :products, only: [:index, :show] do
-        get 'get_seller', to: 'products#get_seller'
+        get 'seller', to: 'products#seller'
       end
       get 'invoices/status/:r_hash', to: 'invoices#status'
       get '/satoshi_price', to: 'prices#satoshi_price'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,8 +3,11 @@ Rails.application.routes.draw do
   get 'buy', to: 'pages#buy'
   scope path: '/api' do
     api_version(module: 'Api::V1', path: { value: 'v1' }, defaults: { format: 'json' }) do
-      resources :products, only: [:index, :show]
+      # resources :products, only: [:index, :show]
       resources :invoices, only: [:create]
+      resources :products, only: [:index, :show] do
+        get 'get_seller', to: 'products#get_seller'
+      end
       get 'invoices/status/:r_hash', to: 'invoices#status'
       get '/satoshi_price', to: 'prices#satoshi_price'
       get '/gif', to: 'gifs#show_random'

--- a/db/migrate/20200131204511_add_slack_user_to_users.rb
+++ b/db/migrate/20200131204511_add_slack_user_to_users.rb
@@ -1,0 +1,5 @@
+class AddSlackUserToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :slack_user, :string, default: ""
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_22_210240) do
+ActiveRecord::Schema.define(version: 2020_01_31_204511) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -153,6 +153,7 @@ ActiveRecord::Schema.define(version: 2020_01_22_210240) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "name", null: false
+    t.string "slack_user", default: ""
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/spec/controllers/api/v1/slack_controller_spec.rb
+++ b/spec/controllers/api/v1/slack_controller_spec.rb
@@ -30,7 +30,8 @@ describe Api::V1::SlackController, type: :controller do
     it "notifies user" do
       post :notify_user, params: {
         user_name: slack_user.profile["display_name_normalized"],
-        user_id: slack_user.profile["id"]
+        user_id: slack_user.profile["id"],
+        message: "hola"
       }
       expect(response).to have_http_status(:success)
     end

--- a/spec/controllers/api/v1/slack_controller_spec.rb
+++ b/spec/controllers/api/v1/slack_controller_spec.rb
@@ -29,7 +29,6 @@ describe Api::V1::SlackController, type: :controller do
     end
     it "notifies user" do
       post :notify_user, params: {
-        user_name: slack_user.profile["display_name_normalized"],
         user_id: slack_user.profile["id"],
         message: "hola"
       }


### PR DESCRIPTION
Se necesita enviar notificaciones a los vendedores cuando alguien fia un producto de ellos.  Fue necesario crear una nueva columna para el modelo usuario que guardara el ID de slack ya que el endpoint para notificar a los usuarios utiliza el ID en vez del canal.  El mensaje se tiene que customizar.  También se necesitaba crear un link al update del perfil del usuario para que los usuarios actuales puedan agregar su ID de slack y recibir notificaciones.  El spec también se actualizó.