### PR TITLE
feat(debtor-mandatory): disable confirm debt button if debtor is not …

### DIFF
--- a/app/javascript/components/payment-error-button.vue
+++ b/app/javascript/components/payment-error-button.vue
@@ -56,6 +56,7 @@
             type="button"
             class="btn"
             v-if="showNameTextBox"
+            :disabled="confirmDebtButtonDisabled"
             @click="confirmDebtButton"
           >
             Confirmar
@@ -100,6 +101,7 @@ export default {
       message: '',
       slackUsers: {},
       selectedUser: {},
+      confirmDebtButtonDisabled: true,
     };
   },
   computed: {
@@ -116,6 +118,7 @@ export default {
   methods: {
     show() {
       this.$modal.show('apology-modal');
+      this.confirmDebtButtonDisabled = true;
       this.showDebtButton = true;
       this.showApologyText = true;
       this.showDebtFinalMessage = false;
@@ -132,6 +135,7 @@ export default {
     },
     getSelectedUser(event) {
       this.selectedUser = event.target.value;
+      if (event) this.confirmDebtButtonDisabled = false;
     },
     confirmDebtButton() {
       this.showCartOnDebtModal = false;


### PR DESCRIPTION
Ahora no se puede avanzar en fiar (en el frontend) sin seleccionar usuario de slack (el botón no se habilitará)
<img width="815" alt="Screen Shot 2020-02-21 at 5 59 10 PM" src="https://user-images.githubusercontent.com/11522707/75071324-e7158000-54d3-11ea-97b4-dcf133ed57d6.png">
